### PR TITLE
Statistical Variable Renaming

### DIFF
--- a/stat_var_renaming/pop_obs_spec_common.proto
+++ b/stat_var_renaming/pop_obs_spec_common.proto
@@ -1,0 +1,30 @@
+syntax = "proto2";
+
+message PopObsSpec {
+  // A property-value pair
+  message PV {
+    optional string prop = 1;
+    optional string val = 2;
+  }
+
+  // Population type.
+  optional string pop_type = 1;
+  // Measured property.
+  optional string mprop = 2;
+  // Values are stat properties like measuredValue, medianValue, etc.
+  optional string stat_type = 3;
+  // Constraining properties of StatisticalPopulation.
+  repeated string cprop = 4;
+  // A list of depending property value pairs that a client does not indicate
+  // but needs to be added.
+  // For example, property "income" needs additional pv of "age=Years15Onwards"
+  repeated PV dpv = 5;
+  // Name for this spec.
+  optional string name = 6;
+  // Verticals of this spec.
+  repeated string vertical = 7;
+}
+// All published Pop/Obs spec. Stored in a textproto.
+message PopObsSpecList {
+  repeated PopObsSpec spec = 1;
+}

--- a/stat_var_renaming/pop_obs_spec_nocovid.textproto
+++ b/stat_var_renaming/pop_obs_spec_nocovid.textproto
@@ -1,0 +1,1707 @@
+## Person Count ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  name: "Population"
+  vertical: "Demographics"
+}
+
+## Person Count 1 cprop ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "citizenship"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "income"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+  dpv: {
+    prop: "incomeStatus"
+    val: "WithIncome"
+  }
+}
+
+## Table B16004 Age by Language Spoken at Home by Ability to Speak English
+## Universe: Population 5 Years and Over
+# [Age] Person Count # Exists
+# languageSpokenAtHome x [Age]
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "languageSpokenAtHome"
+  cprop: "age"
+}
+# abilityToSpeakEnglish x languageSpokenAtHome x [Age]
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "abilityToSpeakEnglish"
+  cprop: "age"
+  cprop: "languageSpokenAtHome"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "maritalStatus"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "nativity"
+  dpv: {
+    prop: "age"
+    val: "Years5Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "placeOfBirth"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "povertyStatus"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "veteranStatus"
+  dpv: {
+    prop: "age"
+    val: "Years18Onwards"
+  }
+  dpv: {
+    prop: "armedForcesStatus"
+    val: "Civilian"
+  }
+}
+
+## Person Count 2 cprops ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "gender"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "placeOfBirth"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "educationalAttainment"
+  cprop: "gender"
+  dpv: {
+    prop: "age"
+    val: "Years25Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "income"
+  cprop: "gender"
+  dpv: {
+    prop: "age"
+    val: "Years16Onwards"
+  }
+  dpv: {
+    prop: "incomeStatus"
+    val: "WithIncome"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "maritalStatus"
+  cprop: "gender"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "povertyStatus"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "gender"
+  cprop: "schoolEnrollment"
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "veteranStatus"
+  dpv: {
+    prop: "age"
+    val: "Years18Onwards"
+  }
+  dpv: {
+    prop: "armedForcesStatus"
+    val: "Civilian"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "income"
+  cprop: "placeOfBirth"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+  dpv: {
+    prop: "incomeStatus"
+    val: "WithIncome"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "incomeStatus"
+  cprop: "placeOfBirth"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "maritalStatus"
+  cprop: "placeOfBirth"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+}
+
+## Table B16005: Nativity by Language Spoken at Home by Ability to Speak English
+## Universe: Population 5 Years and Over
+# Non/Native 5 Years and Over
+# languageSpokenAtHome x Non/Native 5 Years and Over
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "nativity"
+  cprop: "languageSpokenAtHome"
+  dpv: {
+    prop: "age"
+    val: "Years5Onwards"
+  }
+}
+# abilityToSpeakEnglish x languageSpokenAtHome x Non/Native 5 Years and Over
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "abilityToSpeakEnglish"
+  cprop: "nativity"
+  cprop: "languageSpokenAtHome"
+  dpv: {
+    prop: "age"
+    val: "Years5Onwards"
+  }
+}
+
+## Table B16005[A-I]: Nativity by Language Spoken at Home by Ability to Speak English by Race
+## Universe: Population 5 Years and Over
+# Non/Native x Race 5 Years and Over
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "race"
+  cprop: "nativity"
+  dpv: {
+    prop: "age"
+    val: "Years5Onwards"
+  }
+}
+# languageSpokenAtHome x Non/Native x Race 5 Years and Over
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "languageSpokenAtHome"
+  cprop: "nativity"
+  cprop: "race"
+  dpv: {
+    prop: "age"
+    val: "Years5Onwards"
+  }
+}
+# abilityToSpeakEnglish x languageSpokenAtHome (nonEnglish) x Non/Native x Race 5 Years and Over
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "abilityToSpeakEnglish"
+  cprop: "race"
+  cprop: "nativity"
+  dpv: {
+    prop: "age"
+    val: "Years5Onwards"
+  }
+  dpv: {
+    prop: "languageSpokenAtHome"
+    val: "LanguageOtherThanEnglish"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "race"
+  cprop: "povertyStatus"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "race"
+  cprop: "schoolEnrollment"
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+
+## Person Count 3 cprops ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "educationalAttainment"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "healthInsurance"
+  dpv: {
+    prop: "armedForcesStatus"
+    val: "Civilian"
+  }
+  dpv: {
+    prop: "institutionalization"
+    val: "USC_NonInstitutionalized"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "povertyStatus"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "maritalStatus"
+  cprop: "race"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Education"
+  cprop: "detailedLevelOfSchool"
+  cprop: "gender"
+  dpv: {
+    prop: "age"
+    val: "Years25Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "educationalAttainment"
+  dpv: {
+    prop: "age"
+    val: "Years25Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Education"
+  vertical: "Demographics"
+  cprop: "educationalAttainment"
+  cprop: "gender"
+  cprop: "race"
+  dpv: {
+    prop: "age"
+    val: "Years25Onwards"
+  }
+}
+
+## Person Count - Census Tables ##
+
+## Census B14001
+## Universe: Population 3 Years and Over
+# MISSING NotEnrolledInSchool counts, so schoolEnrollment becomes a dpv here
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "levelOfSchool"
+  dpv: {
+    prop: "schoolEnrollment"
+    val: "EnrolledInSchool"
+  }
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+
+## Person Count - Census Tables ##
+
+## Table B14002: Sex by School Enrollment by Level of School by Type of School for the Population 3 Years and Over
+## Universe: Population 3 Years and Over
+# Fe/Male 3+YO # Exists above in Person 1 cprop and Person 2 cprop
+# Fe/Male Not/Enrolled 3+YO # Exists above in Person 2 cprop
+# LevelOfSchool Fe/Male Enrolled 3+YO
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "gender"
+  cprop: "levelOfSchool"
+  dpv: {
+    prop: "schoolEnrollment"
+    val: "EnrolledInSchool"
+  }
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+# Type Of School LevelOfSchool Fe/Male Enrolled 3+YO
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "typeOfSchool"
+  cprop: "gender"
+  cprop: "levelOfSchool"
+  dpv: {
+    prop: "schoolEnrollment"
+    val: "EnrolledInSchool"
+  }
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+
+## Table B14007
+## Universe: Population 3 Years and Over
+# 3+YO Not/Enrolled in school
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Education"
+  cprop: "schoolEnrollment"
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+# Detailed Level of School for 3+YO enrolled in school
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Education"
+  cprop: "detailedLevelOfSchool"
+  dpv: {
+    prop: "schoolEnrollment"
+    val: "EnrolledInSchool"
+  }
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+
+## Table B14007[A-I] School Enrollment by Detailed Level of School [Race]
+## Universe: [Race] Population 3 Years and Over
+# Not/Enrolled in School [Race] 3 Years and Over # exists above in Person 2 cprop
+# Detailed Level of School for Enrolled in School [Race] 3 Years and Over
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "detailedLevelOfSchool"
+  cprop: "race"
+  dpv: {
+    prop: "schoolEnrollment"
+    val: "EnrolledInSchool"
+  }
+  dpv: {
+    prop: "age"
+    val: "Years3Onwards"
+  }
+}
+
+## Table B21001
+## Universe: Civilian Population 18 years and older
+# Veteran/NonVet Civilian Population 18 years and older # exists above
+# Fe/Male Civilian Population 18 years and older # promoted armedForcesStatus
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "armedForcesStatus"
+  dpv: {
+    prop: "age"
+    val: "Years18Onwards"
+  }
+}
+# Fe/Male Non/Vet Civilian Population 18 years and older # exists above under 2 cprop
+# Male Age Civilian Population # promoted armedForcesStatus
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "age"
+  cprop: "armedForcesStatus"
+}
+# Male Age Vet Civilian Population
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "age"
+  cprop: "veteranStatus"
+  dpv: {
+    prop: "armedForcesStatus"
+    val: "Civilian"
+  }
+}
+
+## Table B27003
+## Universe: Civilian Noninstitutionalized Population
+# Male Civilian Noninstitutionalized # promoted armedForcesStatus and institutionalization
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "institutionalization"
+  cprop: "armedForcesStatus"
+}
+# Male Civilian Noninstitutionalized Age # promoted armedForcesStatus and institutionalization
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "institutionalization"
+  cprop: "armedForcesStatus"
+}
+# Male Civilian Noninstitutionalized Age Coverage # exists above in Person 3 cprop
+
+## Person Age ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "age"
+  stat_type: "medianValue"
+  vertical: "Demographics"
+}
+
+## Person Income ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "income"
+  stat_type: "medianValue"
+  vertical: "Demographics"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+  dpv: {
+    prop: "incomeStatus"
+    val: "WithIncome"
+  }
+}
+
+## Person unemploymentRate ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "unemploymentRate"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  name: "Unemployment Rate"
+}
+
+## Person percent ##
+
+spec: {
+  pop_type: "Person"
+  mprop: "percent"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "healthOutcome"
+  dpv: {
+    prop: "age"
+    val: "Years18Onwards"
+  }
+  name: "Health Outcomes"
+}
+
+# This one needs additional config
+spec: {
+  pop_type: "Person"
+  mprop: "percent"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "healthPrevention"
+  dpv: {
+    prop: "age"
+    val: "Years18Onwards"
+  }
+  name: "Health Preventions"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "percent"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "healthBehavior"
+  dpv: {
+    prop: "age"
+    val: "Years18Onwards"
+  }
+  name: "Health Behaviors"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "percent"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "gender"
+  cprop: "healthOutcome"
+  dpv: {
+    prop: "age"
+    val: "Years20Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "percent"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "gender"
+  cprop: "healthBehavior"
+  dpv: {
+    prop: "age"
+    val: "Years20Onwards"
+  }
+}
+
+## CriminalActivities ##
+
+spec: {
+  pop_type: "CriminalActivities"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Crime"
+  cprop: "crimeType"
+}
+
+## MortalityEvent ##
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  name: "Mortality"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "age"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "causeOfDeath"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "gender"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "age"
+  cprop: "causeOfDeath"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "age"
+  cprop: "gender"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "age"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "causeOfDeath"
+  cprop: "gender"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "causeOfDeath"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "gender"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "causeOfDeath"
+  cprop: "gender"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "causeOfDeath"
+}
+
+spec: {
+  pop_type: "MortalityEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Health"
+  cprop: "age"
+  cprop: "race"
+  cprop: "causeOfDeath"
+}
+
+## USCEstablishment ##
+
+spec: {
+  pop_type: "USCEstablishment"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Economics"
+  name: "Number of Establishments"
+}
+
+spec: {
+  pop_type: "USCEstablishment"
+  mprop: "wagesAnnual"
+  stat_type: "measuredValue"
+  vertical: "Economics"
+  name: "Annual Wages of Establishments"
+}
+
+spec: {
+  pop_type: "USCEstablishment"
+  mprop: "wagesAnnual"
+  stat_type: "measuredValue"
+  vertical: "Economics"
+  cprop: "naics"
+  name: "Annual Wages of Establishments by Industry"
+}
+
+## USCWorker ##
+
+spec: {
+  pop_type: "USCWorker"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Economics"
+  name: "Labor Force"
+}
+
+## BLSEstablishment ##
+
+spec: {
+  pop_type: "BLSEstablishment"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  cprop: "naics"
+  name: "Establishments by Industry"
+}
+
+spec: {
+  pop_type: "BLSEstablishment"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  cprop: "establishmentOwnership"
+  cprop: "naics"
+}
+
+## BLSWorker ##
+
+spec: {
+  pop_type: "BLSWorker"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  cprop: "naics"
+  name: "Labor Force by Industry"
+}
+
+spec: {
+  pop_type: "BLSWorker"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  cprop: "establishmentOwnership"
+  cprop: "naics"
+}
+
+# spec: {
+#   pop_type: "BLSWorker"
+#   mprop: "wagesTotal"
+#   stat_type: "measuredValue"
+#   vertical: "Economics"
+#   cprop: "naics"
+#   name: "Labor Force by Industry Total Wages"
+# }
+
+spec: {
+  pop_type: "BLSWorker"
+  mprop: "wagesAnnual"
+  stat_type: "measuredValue"
+  vertical: "Economics"
+  cprop: "naics"
+  cprop: "establishmentOwnership"
+  name: "Annual Wages of Labor Force by Industry and Ownership"
+}
+
+# spec: {
+#   pop_type: "BLSWorker"
+#   mprop: "wagesTotal"
+#   stat_type: "measuredValue"
+#   vertical: "Economics"
+#   cprop: "naics"
+#   cprop: "establishmentOwnership"
+#   name: "Labor Force Total Wages by Industry and Ownership"
+# }
+
+# spec: {
+#   pop_type: "BLSWorker"
+#   mprop: "wagesWeekly"
+#   stat_type: "measuredValue"
+#   vertical: "Economics"
+#   cprop: "naics"
+#   cprop: "establishmentOwnership"
+#   name: "Labor Force Weekly Wages by Industry and Ownership"
+# }
+
+## Household ##
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  name: "Household"
+}
+
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  cprop: "householderAge"
+  name: "Household by Householder Age"
+}
+
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  cprop: "householderRace"
+  name: "Household by Householder Race"
+}
+
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  cprop: "income"
+  name: "Household Income"
+}
+
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  cprop: "householderAge"
+  cprop: "income"
+}
+
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  cprop: "householderRace"
+  cprop: "income"
+}
+
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  cprop: "householderAge"
+  cprop: "householderRace"
+}
+
+spec: {
+  pop_type: "Household"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Household"
+  cprop: "householderAge"
+  cprop: "householderRace"
+  cprop: "income"
+}
+
+## HousingUnit ##
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  name: "Housing Units"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "cashRentStatus"
+  dpv: {
+    prop: "occupancyStatus"
+    val: "OccupiedHousingUnit"
+  }
+  dpv: {
+    prop: "occupancyTenure"
+    val: "RenterOccupied"
+  }
+  name: "Housing Unit Cash Rent Status"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "grossRent"
+  dpv: {
+    prop: "occupancyStatus"
+    val: "OccupiedHousingUnit"
+  }
+  dpv: {
+    prop: "occupancyTenure"
+    val: "RenterOccupied"
+  }
+  dpv: {
+    prop: "cashRentStatus"
+    val: "WithCashRent"
+  }
+  name: "Housing Unit Gross Rent"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "homeValue"
+  dpv: {
+    prop: "occupancyStatus"
+    val: "OccupiedHousingUnit"
+  }
+  dpv: {
+    prop: "occupancyTenure"
+    val: "OwnerOccupied"
+  }
+  name: "Housing Unit Home Value"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "householderRace"
+  dpv: {
+    prop: "occupancyStatus"
+    val: "OccupiedHousingUnit"
+  }
+  name: "Housing Unit Householder Race"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "numberOfRooms"
+  name: "Housing Unit Number of Rooms"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "occupancyStatus"
+  name: "Housing Unit Occupancy Status"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "occupancyTenure"
+  dpv: {
+    prop: "occupancyStatus"
+    val: "OccupiedHousingUnit"
+  }
+  name: "Housing Unit Occupancy Tenure"
+}
+
+spec: {
+  pop_type: "HousingUnit"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Housing"
+  cprop: "householderRace"
+  cprop: "occupancyTenure"
+  dpv: {
+    prop: "occupancyStatus"
+    val: "OccupiedHousingUnit"
+  }
+}
+
+### Person counts with cprops ###
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "race"
+}
+
+#### Left both as cprop as there were 2,3 options, respectively
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "incomeStatus"
+  cprop: "age"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "age"
+  cprop: "collegeOrGraduateSchoolEnrollment"
+  cprop: "gender"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "povertyStatus"
+}
+
+# TODO: check this
+#### Note that in common there is already one but with age 3+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Education"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "schoolEnrollment"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "workExperience"
+  cprop: "gender"
+  dpv: {
+    prop: "age"
+    val: "Years16Onwards"
+  }
+}
+
+#### Chose 16+ age group (among 15+, 16+) for consistency
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "gender"
+  cprop: "incomeStatus"
+  cprop: "workExperience"
+  dpv: {
+    prop: "age"
+    val: "Years16Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "gender"
+  cprop: "race"
+  cprop: "workExperience"
+  dpv: {
+    prop: "age"
+    val: "Years16Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "spousePresent"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+  dpv: {
+    prop: "maritalStatus"
+    val: "NowMarried"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  vertical: "Demographics"
+  cprop: "age"
+  cprop: "gender"
+  cprop: "povertyStatus"
+  cprop: "race"
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "gender"
+  cprop: "income"
+  cprop: "workExperience"
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+  dpv: {
+    prop: "incomeStatus"
+    val: "WithIncome"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "gender"
+  cprop: "incomeStatus"
+  cprop: "race"
+  cprop: "workExperience"
+  dpv: {
+    prop: "age"
+    val: "Years16Onwards"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  cprop: "gender"
+  cprop: "spouseAbsentReason"
+  dpv: {
+    prop: "maritalStatus"
+    val: "NowMarried"
+  }
+  dpv: {
+    prop: "age"
+    val: "Years15Onwards"
+  }
+  dpv: {
+    prop: "spousePresent"
+    val: "MarriedSpouseAbsent"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Demographics"
+  vertical: "Employment"
+  cprop: "gender"
+  cprop: "income"
+  cprop: "race"
+  cprop: "workExperience"
+  dpv: {
+    prop: "age"
+    val: "Years16Onwards"
+  }
+  dpv: {
+    prop: "incomeStatus"
+    val: "WithIncome"
+  }
+}
+
+## Drug Distribution retailDrugDistribution##
+
+spec: {
+  pop_type: "DrugDistribution"
+  mprop: "retailDrugDistribution"
+  cprop: "drugPrescribed"
+  stat_type: "measuredValue"
+  vertical: "Health"
+}
+
+## Disasters ##
+spec: {
+  pop_type: "CycloneEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Disasters"
+  name: "Cyclones"
+}
+spec: {
+  pop_type: "CycloneEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  cprop: "maxClassification"
+  vertical: "Disasters"
+}
+spec: {
+  pop_type: "DroughtEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Disasters"
+  name: "Droughts"
+}
+spec: {
+  pop_type: "EarthquakeEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Disasters"
+  name: "Earthquakes"
+}
+spec: {
+  pop_type: "EarthquakeEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  cprop: "magnitude"
+  vertical: "Disasters"
+}
+spec: {
+  pop_type: "FloodEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Disasters"
+  name: "Floods"
+}
+spec: {
+  pop_type: "ThunderstormWindEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Disasters"
+  name: "Thunderstorm Wind Gusts"
+}
+spec: {
+  pop_type: "TornadoEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Disasters"
+  name: "Tornadoes"
+}
+spec: {
+  pop_type: "WildlandFireEvent"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Disasters"
+  name: "Wildland Fires"
+}
+
+## WDI
+
+# spec: {
+#   pop_type: "Consumption"
+#   mprop: "amount"
+#   stat_type: "measuredValue"
+#   cprop: "consumedThing"
+#   vertical: "Environment"
+#   name: "Consumption"
+# }
+# spec: {
+#   pop_type: "EconomicActivity"
+#   mprop: "amount"
+#   stat_type: "measuredValue"
+#   cprop: "activitySource"
+#   vertical: "Economic"
+#   name: "Economic Activity"
+# }
+# # TODO(b/148618745): uncomment the code once bug fixed.
+# # spec: {
+# #   pop_type: "EconomicActivity"
+# #   mprop: "amount"
+# #   stat_type: "growthRate"
+# #   cprop: "activitySource"
+# #   vertical: "Economic"
+# #   name: "Economic Activity Growth Rate"
+# # }
+# spec: {
+#   pop_type: "Emissions"
+#   mprop: "amount"
+#   stat_type: "measuredValue"
+#   cprop: "emittedThing"
+#   vertical: "Environment"
+#   name: "Emissions"
+# }
+# # TODO(b/148618745): uncomment the code once bug fixed.
+# # spec: {
+# #   pop_type: "Person"
+# #   mprop: "count"
+# #   stat_type: "growthRate"
+# #   vertical: "Demographics"
+# #   name: "Population Growth Rate"
+# # }
+# spec: {
+#   pop_type: "Person"
+#   mprop: "count"
+#   stat_type: "measuredValue"
+#   vertical: "Demographics"
+#   cprop: "isInternetUser"
+#   name: "Number of Internet Users"
+# }
+# spec: {
+#   pop_type: "Person"
+#   mprop: "fertilityRate"
+#   stat_type: "measuredValue"
+#   vertical: "Health"
+#   dpv: {
+#     prop: "gender"
+#     val: "Female"
+#   }
+#   name: "Fertility Rate"
+# }
+# spec: {
+#   pop_type: "Person"
+#   mprop: "lifeExpectancy"
+#   stat_type: "measuredValue"
+#   vertical: "Health"
+#   name: "Life Expectancy"
+# }
+
+# This doesn't work
+# spec: {
+#   pop_type: "MedicalConditionIncident"
+#   mprop: "cumulativeCount"
+#   stat_type: "measuredValue"
+#   vertical: "Health"
+#   name: "Medical Condition Incidents"
+#   cprop: "incidentType"
+# }
+
+# spec: {
+#   pop_type: "MedicalConditionIncident"
+#   mprop: "cumulativeCount"
+#   stat_type: "measuredValue"
+#   vertical: "Health"
+#   name: "COVID-19 Incidents"
+#   dpv: {
+#     prop: "incidentType"
+#     val: "COVID_19"
+#   }
+#   cprop: "medicalStatus"
+# }
+spec: {
+  pop_type: "UnemploymentInsuranceClaim"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  name: "Unemployment Insurance Claims"
+  cprop: "benefitProgram"
+}
+spec: {
+  pop_type: "UnemploymentInsuranceClaim"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  cprop: "benefitProgram"
+  cprop: "claimType"
+}
+
+## TODO(tjann): Whitelist after making this look nicer on GNI PV Tree.
+# spec: {
+#   pop_type: "UnemploymentInsuranceClaim"
+#   mprop: "count"
+#   stat_type: "measuredValue"
+#   vertical: "Employment"
+#   dpv: {
+#     prop: "benefitProgram"
+#     val: "StateUnemploymentInsuranceOrShortTimeCompensation"
+#   }
+#   dpv: {
+#     prop: "claimType"
+#     val: "ContinuedClaim"
+#   }
+#   name: "13-Week Moving Average State Unemployment Insurance or Workshare Claims"
+# }
+# spec: {
+#   pop_type: "Person"
+#   mprop: "insuredUnemploymentRate"
+#   stat_type: "measuredValue"
+#   vertical: "Employment"
+#   dpv: {
+#     prop: "unemploymentInsuranceStatus",
+#     val: "WithCoveredEmployment"
+#   }
+#   name: "13-Week Moving Average Insured Unemployment Rate"
+# }
+
+## Person Count ##
+
+### employment and employmentStatus as depdendent pv ###
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  name: "Labor Force"
+  dpv: {
+    prop: "employmentStatus"
+    val: "BLS_InLaborForce"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  name: "Employed"
+  dpv: {
+    prop: "employment"
+    val: "BLS_Employed"
+  }
+}
+
+spec: {
+  pop_type: "Person"
+  mprop: "count"
+  stat_type: "measuredValue"
+  vertical: "Employment"
+  name: "Unemployed"
+  dpv: {
+    prop: "employment"
+    val: "BLS_Unemployed"
+  }
+}
+

--- a/stat_var_renaming/stat_var_renaming.py
+++ b/stat_var_renaming/stat_var_renaming.py
@@ -1,0 +1,644 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file performs the renaming of all statistical variables present in the Data Commons Knowledge Graph. These StatVar names are incredible useful for end-users as they may be pulled from both the python API 
+or Google Sheets API by name. 
+
+1) Base Schema: The basic schema for any human readable statistical variable is
+mprop_popType_v1_v2_v3...
+For example, Count_Person_BornInStateOfResidence
+
+2) Optional inclusion of StatType
+StatType is included when the StatType is not measuredValue or Unknown.
+For example, instead of Age_Person, we output MedianAge_Person
+
+3) Certain data sets are blacklisted
+For example, all bio data sets and a few miscellaneous ones are excluded. This blacklist was created by Tiffany. 
+
+4) Dependent variables are removed. 
+Dependent variables are constraints that are inherently included, but not really necessary. For example, a person earning an income of 10k to 15k USD may only be measured by the census if they are older than 15 and have an income. For example, "Count_Person_Years15Onwards_IncomeOfUSDollar10000To14999_WithIncome" becomes "Count_Person_IncomeOfUSDollar10000To14999" after accounting for the unnecessary variables. These dependent variables are defined in the textproto stat vars config file. 
+
+4) Boolean constraints are replaced by their populations
+E.g. p1 = isInternetUser and v1=True/False becomes v1=isInternetUser/notInternetUser. 
+
+5) Measurement properties are stripped from constraints.
+E.g. p1 = employment and v1 = USC_Unemployed becomes v1=Unemployed
+
+6) NAICS Industry codes are replaced by industry names.
+We have a combination of NAICS specific and overview codes. In both cases, we replace the industry code (e.g. NAICS/23) with the industry.
+An example statistical variable is WagesAnnual_Establishment_NAICSConstruction
+
+7) Cause of death properties are renamed.
+E.g. p1 = causeOfDeath and v1="ICD10/E00-E89" becomes v1="EndocrineNutritionalMetabolicDiseases". These names are generated directly from the ICD10 names stored in BigQuery. For exceptionally long or confusing names, I manually renamed them.
+
+8) DEA drug names are renamed
+E.g. p1="drugPrescribed" and v1="drug/dea/9250" becomes v1="Methadone". These are manually renamed. Some drug names are intentionally left as their codes. For example, dea/7444 corresponds to "4-Hydroxy-3-methoxy-methamphetamine", which does not have a common name. Both the codes and drug names will be valid constraints.
+
+9) Certain variables have text pre/postpended to their constraints to improve readability.
+For example p1 = childSchoolEnrollment and v1=EnrolledInPublicSchool is changed to v1="ChildEnrolledInPublicSchool". These mappings are applied to ~15 variables. 
+
+e.g. Count_Parent_Years16Onwards_EnrolledInPublicSchool_InLaborForce
+becomes Count_Parent_Years16Onwards_ChildEnrolledInPublicSchool_InLaborForce
+
+10) Misc. changes
+a) MeasuredProp InsuredUnemploymentRate changed to Rate_InsuredUnemployment to match the existing formula. 
+"""
+
+from absl import app
+from google.protobuf import text_format
+from google.cloud import bigquery
+from google.colab import auth
+import re
+import os
+import pandas as pd
+
+from stat_var_renaming_constants import *
+
+### Constants
+# Max total number of constraints of a variable to include (Depedent variables excluded)
+MAX_CONSTRAINTS = 3
+
+def authenticate_bq_client():
+  """ Authenticates and returns a BigQuery client connection. """
+
+  # TODO how should this authentication happen in prod?
+  auth.authenticate_user()
+
+  project_id = "google.com:datcom-store-dev"
+  client = bigquery.Client(project=project_id)
+
+  return client
+
+def download_stat_vars(client):
+  """ Queries unique list of statistical variables from BigQuery.
+
+  Creates a join across statistical populations and observations to generate distinct list. 
+  Certain datasets like bio are excluded. The original dpvs are copied to a new columns.
+
+  Returns:
+      stat_vars: Pandas dataframe containing unique information for all stat vars in the databaes
+
+  Raises:
+      ...
+  """
+  max_constraints_with_dpv = 6
+
+  # Populate constraints
+  constraint_string, pop_string = "", ""
+  for num in range(1, MAX_CONSTRAINTS + 1):
+    constraint_string += f"SP.v{num} as v{num},\n"
+    pop_string += f"SP.p{num} as p{num},\n"
+
+  blacklist = ['"%s"' % prov_id for prov_id in frozenset().union(*[_MISC_DATASETS, _BIO_DATASETS])]
+  blacklist_str = ', '.join(blacklist) if blacklist else '""'
+
+  query_for_all_stat_vars = QUERY_FOR_ALL_STAT_VARS.replace("{CONSTRAINTS}", constraint_string) \
+                                                  .replace("{POPULATIONS}", pop_string) \
+                                                  .replace("{comma_sep_prov_blacklist}", blacklist_str) \
+                                                  .replace("{MAX_CONTRAINTS}", str(MAX_CONSTRAINTS))
+
+  # Perform BQ query
+  stat_vars = client.query(query_for_all_stat_vars).to_dataframe()
+
+  # Original stat vars are preserved for output MCF
+  for c in range(1, max_constraints_with_dpv + 1):
+    stat_vars[f"orig_p{c}"] = stat_vars[f"p{c}"]
+    stat_vars[f"orig_v{c}"] = stat_vars[f"v{c}"]
+
+  return stat_vars
+
+### Variable renaming scripts
+def addPropertyRemapping(remapper, prop, function):
+  """ Helper function to add new remapping function to a certain property.
+
+  Args:
+    remapper: Dictionary with mapping from populations to functions
+    prop: Property to perform remapping on
+    function: Function that takes two arguments (property, constraint) and returns the new name for the constraint
+  """
+
+  if prop not in remapper:
+    remapper[prop] = []
+
+  remapper[prop].append(function)
+
+def remap_numerical_quantities(prop_remap):
+  """ Adds a remapping function to change numerical quantities to a more readable format dependent on regex rules. 
+  
+    Example:  'Years15Onwards' -> '15OrMoreYears' or  'Years25To44' -> '25To44Years'
+  """
+  def rename_constraint(_, constraint):
+    if not pd.isna(constraint):
+      # REGEX_NUMERICAL_QUANTITY_RENAMINGS has mappings from a regex expression to a remapping function
+      for regex, rename_func in REGEX_NUMERICAL_QUANTITY_RENAMINGS:
+        match_obj = regex.match(constraint)
+        if match_obj != None:
+          return rename_func(match_obj)
+      return constraint
+
+  # Opt-in list to rename
+  for prop in NUMERICAL_QUANTITY_PROPERTIES_TO_REMAP:
+    addPropertyRemapping(prop_remap, prop, rename_constraint)
+
+  return prop_remap
+
+def rename_naics_codes(prop_remap):
+  """ Adds a remapping function to change NAICS codes to their corresponding industry.
+  
+    Example: (NAICS, NAICS/23) -> Construction)
+  """
+  # Add renaming function
+  def rename_naics(NAICS_MAP, industry_code):
+    full_code = industry_code.lstrip("NAICS/")
+
+    # If its a range then take the lower bound. E.g. 31-33 = Manufacturing
+    if "-" in full_code:
+      full_code = full_code.split("-")[0]
+
+    two_digit_code = full_code[0:2]
+
+    if full_code in NAICS_MAP:
+      return NAICS_MAP[full_code]
+
+    if two_digit_code in NAICS_MAP:
+      return NAICS_MAP[two_digit_code]
+
+    print(f"Industry Code {industry_code} not found!")
+    assert False
+
+  contextual_rename = lambda _, industry_code: rename_naics(NAICS_MAP, industry_code)
+  addPropertyRemapping(prop_remap, "naics", contextual_rename)
+
+  return prop_remap
+
+def rename_boolean_variables(prop_remap, stat_vars):
+  """ Remaps all variables with boolean constraint values.
+
+    Example (hasComputer, False) -> noComputer 
+  """
+  def map_boolean_constraints(population, value):
+    assert (value == "True" or value == "False")
+    constraint_value = True if value == "True" else False
+    pop, prefix = None, None
+
+    if population.startswith("has"):
+      pop = population.lstrip("has")
+      prefix = "Has" if constraint_value else "N
+    elif population.startswith("is"):
+      pop = population.lstrip("is")
+      prefix = "Is" if constraint_value else "Not"
+    else:
+      print("Unhandled prefix {population}")
+      assert False
+
+    return prefix + pop
+
+
+  # Get all properties with boolean 
+  boolean_populations = set()
+  for c in range(1, MAX_CONSTRAINTS+1):
+    unique_constraints = stat_vars[stat_vars[f"v{c}"].isin(['True', 'False'])][f"p{c}"].unique()
+    boolean_populations.update(unique_constraints)
+
+  for pop in boolean_populations:
+    addPropertyRemapping(prop_remap, pop, map_boolean_constraints)
+  
+  return prop_remap
+
+def prefix_strip(prop_remap):
+  """ Strips measurement method prefixes from constraints.
+
+    Example: BLS_InLaborForce -> InLaborForce
+  """
+
+  for population, prefixes in CONSTRAINT_PREFIXES_TO_STRIP.items():
+    def strip_prefixes(pop, constraint):
+      # Prefixes may be a list or single value
+      prefixes_for_pop = prefixes if isinstance(prefixes, list) else [prefixes]
+
+      for prefix in prefixes_for_pop:
+        if constraint.startswith(prefix):
+          constraint = constraint.replace(prefix, "")
+          return constraint.lstrip("_")
+
+      return constraint
+
+    addPropertyRemapping(prop_remap, population, strip_prefixes)
+
+  return prop_remap 
+
+def cause_of_death_remap(prop_remap, client):
+  """ Remaps ICD10 death codes into full names.
+
+    Example: (causeOfDeath, ICD10/A00-B99) -> CertainInfectiousParasiticDiseases
+  """
+
+  # Query all drug names from cluster
+  cause_of_death_query = """
+  SELECT id, name
+  FROM `google.com:datcom-store-dev.dc_v3_clustered.Instance`
+  WHERE type = "ICD10Section" or type = "ICD10Code"
+  """
+  cause_of_death_instances = client.query(cause_of_death_query).to_dataframe()
+
+  # Simplify Names
+  def provide_consistent_naming(row):
+    id = row['ICD10Code']
+
+    # Manually remap abnormally long names
+    if id in MANUAL_CAUSE_OF_DEATH_RENAMINGS:
+      return MANUAL_CAUSE_OF_DEATH_RENAMINGS[id]
+    
+    # Otherwise just generate from the database name
+    icd10_code = id.replace("ICD10/", "")
+
+    name = row['name']
+    name = name.replace(icd10_code, "").strip().lstrip("(").rstrip("()")
+    name = standard_name_remapper(name)
+
+    row['id'] = id
+    row['name'] = name
+    return row
+
+  cause_of_death_instances["ICD10Code"] = cause_of_death_instances["id"]
+  cause_of_death_instances = cause_of_death_instances.set_index("id")
+  cause_of_death_instances = cause_of_death_instances.apply(provide_consistent_naming, axis=1)
+
+  # Add modification function
+  def death_id_to_name(_, death_id):
+    return cause_of_death_instances.loc[death_id]['name']
+  
+  addPropertyRemapping(prop_remap, 'medicalCode', death_id_to_name)
+  addPropertyRemapping(prop_remap, 'causeOfDeath', death_id_to_name)
+
+def rename_dea_drugs(prop_remap, client):
+  """ Renames dea drig codes to common names.
+  Note that some codes are intentionally unmapped as they are exceptionally long and do not have common usage.
+  The dea drug names were not in a "nice" format so they are manually renamed.
+
+  Example: (drugPrescribed, drug/dea/4000) -> AnabolicSteroids
+  """
+  # Add modification function
+  def drug_id_to_name(_, drug_id):
+    if drug_id in DRUG_REMAPPINGS:
+      return DRUG_REMAPPINGS[orig_name]
+    else:
+      return orig_name.replace("drug/", "") 
+
+  addPropertyRemapping(prop_remap, 'drugPrescribed', drug_id_to_name)
+
+def misc_mappings(prop_remap):
+  """ Any misc. renamings that need to happen should go here.
+  
+    1) Remove ACSED from memberStatus
+    2) Quantity for dateBuilt refers to time not count
+  """
+  def remove_acsed(_, constraint):
+    return constraint.replace("ACSED", "")
+
+  addPropertyRemapping(prop_remap, 'memberStatus', remove_acsed)
+
+  def replace_date_built(_, constraint):
+    constraint = constraint.replace("OrMore", "OrLater")
+    constraint = constraint.replace("Upto", "Before")
+    return constraint
+
+  addPropertyRemapping(pop_remap, 'dateBuilt', replace_date_built)
+
+def pre_postpend_text(prop_remap):
+  """ Adds remapping functions which either prepend or postpend text to all constraints for a property.
+
+    Example: (languageSpokenAtHome, AfricanLanguages) -> AfricanLanguagesSpokenAtHome 
+  """
+  def addTextToConstraint(variable, prepend="", postpend=""):
+    text_mod = lambda _, text: prepend + capitalizeFirst(text) + postpend
+    addPropertyRemapping(prop_remap, variable, text_mod)
+
+  addTextToConstraint("languageSpokenAtHome", postpend="SpokenAtHome")
+  addTextToConstraint("childSchoolEnrollment", prepend="Child")
+  addTextToConstraint("residenceType", prepend="ResidesIn")
+  addTextToConstraint("healthPrevented", prepend="Received")
+  addTextToConstraint("householderAge", prepend="HouseholderAge")
+  addTextToConstraint("householderRace", prepend="HouseholderRace")
+  addTextToConstraint("dateBuilt", postpend="Built")
+  addTextToConstraint("homeValue", prepend="HomeValue")
+  addTextToConstraint("numberOfRooms", prepend="WithTotal")
+  addTextToConstraint("naics", prepend="NAICS")
+  addTextToConstraint("isic", prepend="ISIC")
+  addTextToConstraint("establishmentOwnership", postpend="Establishment")
+  addTextToConstraint("householdSize", prepend="With")
+  addTextToConstraint("numberOfVehicles", prepend="With")
+  addTextToConstraint("income", prepend="IncomeOf")
+  addTextToConstraint("grossRent", prepend="GrossRent")
+  addTextToConstraint("healthOutcome", prepend="With")
+  addTextToConstraint("healthPrevention", prepend="Received")
+  addTextToConstraint("propertyTax", prepend="YearlyTax")
+
+def rename_isic_codes(prop_remap, client):
+  """ Renames all ISIC economic codes to their full names in the database.
+
+    Example: (isic, ISICv3.1/I) -> ISICTransportStorageCommunications
+  """
+
+  # Download all isic codes names from cluster
+  ISIC_QUERY = """
+  SELECT id, name
+  FROM `google.com:datcom-store-dev.dc_v3_clustered.Instance` 
+  WHERE type = "ISICv3.1Enum"
+  """
+  isic_instances = client.query(ISIC_QUERY).to_dataframe()  
+  isic_instances = isic_instances.set_index("id")
+  isic_instances['name'] = isic_instances['name'].apply(standard_name_remapper)
+
+  # Add modification function
+  def isic_id_to_name(_, isic):
+    return isic_instances.loc[isic]['name']
+  
+  addPropertyRemapping(prop_remap, 'isic', isic_id_to_name)
+
+def remap_constraint_from_prop(row, prop_remap):
+  """ Helper which applies property remappings to all constraints in a dataset
+
+  Args:
+    row: Pandas row to apply function to.
+    prop_remap: Dictionary mapping property names to functions that take (property, constraint) -> new constraint name
+  """
+  for constraint in range(1, 1+row['numConstraints']):
+    prop = row[f"p{constraint}"]
+
+    if prop in prop_remap:
+      # May need to apply multiple functions for a single property
+      remapper = prop_remap[prop]
+      for function in remapper:
+        row[f"v{constraint}"] = function(prop, row[f"v{constraint}"])
+
+  return row
+
+### Renaming Population
+def rename_populations(stat_vars):
+  """ Applies various rules to remap population names for the stat vars
+    
+    1) Strips measurement prefixes. E.g. BLS_Worker -> Worker
+    2) Renames populations entirely. E.g. MortalityEvent -> Death
+  """
+
+  # Strip prefixes
+  population_prefixes_to_strip = ['BLS', 'USC', 'ACSED']
+
+  def strip_population_prefixes(population):
+    for prefix in population_prefixes_to_strip:
+      if population.startswith(prefix):
+        return re.sub(f"^{prefix}", "", population)
+
+    return population
+
+  stat_vars['populationType'] = stat_vars['populationType'].apply(strip_population_prefixes)
+
+  # Rename populations
+  populations_to_rename = {
+    'MortalityEvent': 'Death',
+  }
+
+  stat_vars['populationType'] = stat_vars['populationType'].apply(lambda pop: pop if pop not in populations_to_rename else populations_to_rename[pop])
+
+  return stat_vars
+
+### Remove dependent variables
+def generate_dependent_variable_list():
+  """ Dynamically creates object proto spec from include file then imports this newly created spec
+  and uses it to load list of depedent variables.
+  
+    Returns:
+      obs_spec_list: Observation specification list
+  """
+
+  # Generate population observation spec
+  os.system("protoc -I=. --python_out=. pop_obs_spec_common.proto")
+
+  # Dynamically load newly created package
+  import pop_obs_spec_common_pb2
+  obs_spec_list = pop_obs_spec_common_pb2.PopObsSpecList()
+
+  # Load in PV list from spec proto
+  # Note that covid cases was temporarily added as a DPV for cases, but truly shouldn't be one
+  with open("pop_obs_spec_nocovid.textproto") as f:
+    counts = f.read()
+    text_format.Parse(counts, obs_spec_list)
+
+  return obs_spec_list
+
+def remove_depedent_variables(stat_vars):
+  """ Removes all dependent variables from list of stat vars.
+
+    Args:
+      stat_vars: Pandas dataframe holding all stat vars
+    
+    Returns:
+      stat_vars with all dependent variables imputed in place and not shifted.
+
+    Notes: 
+      Constraints in database are alphabetically sorted. This method should be updated to take advantage of this guarantee
+      instead of having to search through all columns.
+  """
+
+  # Generate list of depedent vars
+  obs_spec_list = generate_dependent_variable_list()
+
+  # Create single list of constraints for stat vars
+  def cpropsToList(row):
+    cprop_list = []
+
+    for c in range(1, MAX_CONSTRAINTS + 1): 
+      next_pop = row[f"p{c}"]
+      if not pd.isna(next_pop != None:
+        cprop_list.append(next_pop)
+
+    return cprop_list
+
+  stat_vars['CPropList'] = stat_vars.apply(cpropsToList, axis=1)
+
+  # For each depedent variable, get the rows with the matching constraints then remove any DPVs
+  for spec in obs_spec_list.spec:
+    pop_type = spec.pop_type
+    measured_property = spec.mprop
+    stat_type = spec.stat_type
+
+    # Get subset of rows with a match
+    rows_with_indepedent_matches = stat_vars.query(f"populationType == '{pop_type}' and measuredProp == '{measured_property}' and statType == '{stat_type}'")
+
+    # Find any rows with the matching constraining properties
+    for cprop in spec.cprop:
+      rows_with_indepedent_matches['CPropContained'] = rows_with_indepedent_matches['CPropList'].apply(lambda c_prop_list: cprop in c_prop_list)
+      rows_with_indepedent_matches = rows_with_indepedent_matches.query("CPropContained == True")
+
+    # Erase all depedent variables for each constraint
+    for c in range(1, MAX_CONSTRAINTS + 1):
+      for dpv in spec.dpv:
+        rows_to_erase = matching_common_rows.query(f"p{c} == '{dpv.prop}' and v{c} == '{dpv.val}'")
+        stat_vars.loc[rows_to_erase.index, f"p{c}"] = np.nan
+        stat_vars.loc[rows_to_erase.index, f"v{c}"] = np.nan
+
+        stat_vars.loc[rows_to_erase.index, f"numConstraints"] = stat_vars.loc[rows_to_erase.index, f"numConstraints"].apply(lambda num: num - 1)
+
+  return stat_vars
+
+# Shift over any removed stat var columns
+def left_fill_columns(row):
+  ROW_CONSTRAINTS = row['numConstraints']
+
+  location_of_last_found = 2
+  for curr_col in range(1, ROW_CONSTRAINTS + 1):
+    if pd.isna(row[f"p{curr_col}"]):
+      while location_of_last_found <= MAX_CONSTRAINTS:
+        if not pd.isna(row[f"p{location_of_last_found}"]):
+          row[f"p{curr_col}"] = row[f"p{search}"]
+          row[f"v{curr_col}"] = row[f"v{search}"]
+          row[f"p{search}"] = np.nan
+          row[f"v{search}"] = np.nan
+        location_of_last_found += 1
+
+  return row
+  
+def row_to_human_readable(row):
+  """ Applies a mapping between a row in the stat vars dataframe to the corresponding human readable dcid. """
+
+  # Base is measuredProp_PopType => e.g. Count_InsuranceClaims
+  human_string = f"{capitalizeFirst(row['measuredProp'])}_{capitalizeFirst(row['populationType'])}"
+
+  # Prepend StatType
+  stat_type = row['statType']
+  if stat_type != "measuredValue" and stat_type != "Unknown":
+    human_string = capitalizeFirst(stat_type.replace("Value", "")) + "_" + human_string
+
+  # Add Constraints
+  num_constrains = int(row['numConstraints'])
+  for num in range(1, num_constrains + 1): 
+    constraint = row[f"v{num}"]
+
+    if not pd.isna(constraint):
+      human_string += f"_{constraint}"
+
+  # Postpend measurement denominator
+  measurement_denominator = row['measurementDenominator']
+  if not pd.isna(measurement_denominator):
+    if measurement_denominator == "PerCapita":
+      human_string = f"{human_string}_PerCapita"
+    else:
+      human_string = f"{human_string}_AsAFractionOf{measurement_denominator}"
+
+  # Prepend nmeasurement qualifier
+  measurement_qualifier = row['measurementQualifier']
+  if not pd.isna(measurement_qualifier):
+    human_string = f"{measurement_qualifier}_{human_string}" 
+
+  return human_string
+
+def build_original_constraints(row):
+  """ Helper to build list of original properties and constraints. Used to generate output MCF. """
+
+  constraints_text = ""
+  next_constraint = 1
+
+  while next_constraint <= MAX_CONSTRAINTS and not pd.isna(row[f"orig_p{next_constraint}"]):
+    variable = row[f'orig_p{next_constraint}']
+    constraint = row[f'orig_v{next_constraint}']
+    constraints_text += f"{variable}: dcs:{constraint}\n"
+    next_constraint += 1
+
+  return constraints_text
+  
+def row_to_stat_var(row):
+  """ Creates MCF output for the human readable stat var from the row of a pandas dataframe """
+
+  new_stat_var = TEMPLATE_STAT_VAR
+
+  new_stat_var = new_stat_var.replace("{human_readable_dcid}", row['HumanReadableName'])\
+    .replace("{populationType}", row['populationType'])\
+    .replace("{statType}", row['statType'])\
+    .replace("{measuredProperty}", row['measuredProp'])\
+    .replace("{CONSTRAINTS}", row_to_constraints(row))
+
+  if not pd.isna(row['scalingFactor']):
+    new_stat_var = new_stat_var + f"scalingFactor: dcs:{row['scalingFactor']}\n"
+
+  if not pd.isna(row['measurementDenominator']):
+    new_stat_var = new_stat_var + f"measurementDenominator: dcs:{row['measurementDenominator']}\n"
+
+  if not pd.isna(row['measurementQualifier']):
+    new_stat_var = new_stat_var + f"measurementQualifier: dcs:{row['measurementQualifier']}\n"  
+
+  return new_stat_var
+
+def main(argv):
+  """ Executes the downloading, preprocessing, renaming, and output of MCF stat var renaming """
+  client = authenticate_bq_client()
+
+  # Query for stat vars
+  stat_vars = download_stat_vars(client)
+
+  # Build constraint remappings
+  prop_remap = {}
+  rename_naics_codes(prop_remap)
+  rename_dea_drugs(prop_remap, client)
+  rename_isic_codes(prop_remap, client)
+  cause_of_death_remap(prop_remap, client)
+  prefix_strip(prop_remap)
+  rename_boolean_variables(prop_remap, stat_vars)
+  remap_numerical_quantities(prop_remap)
+  pre_postpend_text(prop_remap)
+  misc_mappings(prop_remap)
+
+  # Apply constraint renamings
+  stat_vars = stat_vars.apply(lambda row: remap_constraint_from_prop(row, prop_remap), axis=1)
+
+  # Remove dependent variables
+  stat_vars = remove_depedent_variables(stat_vars)
+  stat_vars = left_fill_columns(stat_vars)
+
+  # Generate human readable names
+  stat_vars['HumanReadableName'] = stat_vars.apply(row_to_human_readable)
+
+  # Manually rename special case
+  stat_vars.loc[stat_vars['HumanReadableName'] == 'Count_Death_Medicare', 'HumanReadableName'] = "Count_Death_MedicareEnrollee" 
+
+  # Filter's for final stat vars
+  stat_vars = stat_vars.query("numConstraints <= 3")
+  stat_vars = stat_vars.query("statType != 'Unknown'")
+
+  # Temporary filters
+  stat_vars = stat_vars.query("measuredProp != 'cohortScaleAchievement'")
+  stat_vars = stat_vars.query("measuredProp != 'gradeCohortScaleAchievement'")
+  stat_vars = stat_vars.query("populationType != 'AcademicAssessmentEvent'")
+  all_but_disaster_populations = []
+  for popType in populationTypes:
+    if "Event" not in popType or popType in ['MortalityEvent', 'AcademicAssessmentEvent']:
+      disaster_populations.append(popType)
+
+  stat_vars = stat_vars[stat_vars['populationType'].isin(all_but_disaster_populations)]
+  stat_vars = stat_vars.sort_values(['numConstraints', 'measuredProp', 'populationType', 'p1', 'p2', 'p3', 'v1', 'v2', 'v3'])
+
+  # Output MCF
+  with open('renamed_stat_vars.mcf', 'w', newline='') as f_out:
+    for index, row in stat_vars.iterrows():
+      new_stat_var = row_to_stat_var(row)
+      f_out.write(new_stat_var)
+
+  # Output CSV
+  stat_vars = stat_vars.fillna("None")
+  stat_vars[['numConstraints', 'populationType', 'measuredProp', 'p1', 'v1', 'p2', 'v2', 'p3', 'v3', 'HumanReadableName', 'orig_p1', 'orig_v1', 'orig_p2', 'orig_v2', 'orig_p3', 'orig_v3', 'orig_p4', 'orig_v4']].to_csv("output.csv", index=False)
+
+if __name__ == '__main__':
+  app.run(main)
+
+
+

--- a/stat_var_renaming/stat_var_renaming_constants.py
+++ b/stat_var_renaming/stat_var_renaming_constants.py
@@ -1,0 +1,265 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+  This file contains various constants and helper code to generate constants that are used in the Statistical Variable renaming. 
+"""
+
+import pandas as pd
+import re
+
+### Helper Functions
+def standard_name_remapper(orig_name):
+  """ Renames lists into camel case without spaces """
+
+  # Remove text after first paren
+  paren_start = orig_name.find("(")
+  if paren_start != -1:
+    orig_name = orig_name[:paren_start]
+
+  # New text
+  orig_name = orig_name.replace(",", " ")
+  orig_name = orig_name.replace("-", " ")
+  orig_name = orig_name.replace("and ", "")
+  return "".join([word.capitalize() for word in orig_name.split(" ")])
+
+### Code that generates constants
+def _create_naics_map():
+  """ Downloads all NAICS codes across long and short form codes """
+
+  # Read in list of industry topics
+  naics_codes = pd.read_excel("https://www.census.gov/eos/www/naics/2017NAICS/2-6%20digit_2017_Codes.xlsx")
+  naics_codes = naics_codes.iloc[:, [1,2]]
+  naics_codes.columns = ['NAICSCode', 'Title']
+
+  # Replace all ranges with individual rows. E.g. 31-33 -> 31, 32, 33
+  def range_to_array(read_code):
+    if isinstance(read_code, str) and "-" in read_code:
+      lower, upper = read_code.split("-")
+      return list(range(int(lower), int(upper) +1))
+
+    # Not a range
+    else:
+      return read_code
+
+  naics_codes = naics_codes.dropna()
+  naics_codes['NAICSCode'] = naics_codes['NAICSCode'].apply(range_to_array)
+  naics_codes = naics_codes.explode('NAICSCode')
+
+  # Add Unclassified
+  naics_codes = naics_codes.append({"NAICSCode": 99, "Title": "Nonclassifiable"}, ignore_index=True)
+
+  # Query for only two letter codes
+  short_codes = naics_codes[naics_codes['NAICSCode'] < 100]
+  short_codes = short_codes.set_index("NAICSCode")
+  short_codes = short_codes['Title'].to_dict()
+
+  # Read in overview codes
+  overview_codes = pd.read_csv("https://data.bls.gov/cew/doc/titles/industry/high_level_industries.csv")
+  overview_codes.columns = ["NAICSCode", "Title"]
+  overview_codes = overview_codes.set_index("NAICSCode")
+  overview_codes = overview_codes['Title'].to_dict()
+
+  # Rename all columns to new schema
+  NAICS_MAP = {}
+
+  combined_codes = short_codes
+  combined_codes.update(overview_codes)
+
+  # Rename industries into camel case
+  for code, orig_name in combined_codes.items():
+    NAICS_MAP[str(code)] = standard_name_remapper(orig_name)
+
+  # Other edge cases
+  NAICS_MAP['00'] = 'Unclassified'
+
+  return NAICS_MAP
+
+NAICS_MAP = _create_naics_map()
+
+### True Constants
+# Main query for stat vars
+QUERY_FOR_ALL_STAT_VARS = """
+SELECT
+DISTINCT SP.population_type as populationType,
+{CONSTRAINTS}
+{POPULATIONS}
+O.measurement_qualifier AS measurementQualifier,
+O.measurement_denominator as measurementDenominator,
+O.measured_prop as measuredProp,
+SP.num_constraints as numConstraints,
+IF(O.measured_value IS NOT NULL, "measuredValue",
+    IF(O.sum_value IS NOT NULL, "sumValue",
+    IF(O.mean_value IS NOT NULL, "meanValue",
+        IF(O.min_value IS NOT NULL, "minValue",
+            IF(O.max_value IS NOT NULL, "maxValue",
+                IF(O.std_deviation_value IS NOT NULL, "stdDeviationValue",
+                IF(O.growth_rate IS NOT NULL, "growthRate",
+                    IF(O.median_value IS NOT NULL, "medianValue", "Unknown")))))))) AS statType,
+FROM `google.com:datcom-store-dev.dc_v3_dev.StatisticalPopulation` AS SP
+JOIN `google.com:datcom-store-dev.dc_v3_clustered.Observation` AS O ON TRUE
+WHERE
+SP.id = O.observed_node_key
+AND O.type <> "ComparativeObservation"
+AND SP.is_public = True
+AND SP.prov_id NOT IN ({comma_sep_prov_blacklist})
+"""
+
+# Dataset blacklist
+_BIO_DATASETS = frozenset([
+  'dc/p47rsv3',  # UniProt
+  'dc/0cwj4g1',  # FDA_Pharmacologic_Class
+  'dc/5vxrbh3',  # SIDER
+  'dc/ff08ks',   # Gene_NCBI
+  'dc/rhjyj31',  # MedicalSubjectHeadings
+  'dc/jd648v2',  # GeneticVariantClinVar
+  'dc/x8m41b1',  # ChEMBL
+  'dc/vbyjkh3',  # SPOKESymptoms
+  'dc/gpv9pl2',  # DiseaseOntology
+  'dc/8nwtbj2',  # GTExSample0
+  'dc/t5lx1e2',  # GTExSample2
+  'dc/kz0q1c2',  # GTExSample1
+  'dc/8xcvhx',   # GenomeAssemblies
+  'dc/hgp9hn1',  # Species
+  'dc/9llzsx1',  # GeneticVariantUCSC
+  'dc/f1fxve1',  # Gene_RNATranscript_UCSC
+  'dc/mjgrfc',   # Chromosome
+  'dc/h2lkz1',   # ENCODEProjectSample
+])
+
+_MISC_DATASETS = frozenset([
+  'dc/93qydx3',  # NYBG
+  'dc/g3rq1f1',  # DeepSolar
+  'dc/22t2hr3',  # EIA_860
+  'dc/zkhvp12',  # OpportunityInsightsOutcomes
+  'dc/89fk9x3',  # CollegeScorecard
+])
+
+# List of constraint prefixes to remove from certain properties 
+CONSTRAINT_PREFIXES_TO_STRIP = {
+  'nativity': 'USC',
+  'age': 'USC',
+  'institutionalization': 'USC',
+  'educationStatus': 'USC',
+  'povertyStatus': 'USC',
+  'workExperience': 'USC',
+  'nativity': 'USC',
+  'race': ['USC', 'CDC', 'DAD'],
+  'employment': ['USC', 'BLS'],
+  'employmentStatus': ['USC', 'BLS'],
+  'schoolGradeLevel': 'NCES',
+  'patientRace': 'DAD'
+}
+
+# List of drug renamings. Note that some drugs are intentionally excluded.
+DRUG_REMAPPINGS = {
+ 'drug/dea/1100': 'Amphetamine',
+ 'drug/dea/1105B': 'DlMethamphetamine',
+ 'drug/dea/1105D': 'DMethamphetamine',
+ 'drug/dea/1205': 'Lisdexamfetamine',
+ 'drug/dea/1248': 'Mephedrone',
+ 'drug/dea/1615': 'Phendimetrazine',
+ 'drug/dea/1724': 'Methylphenidate',
+ 'drug/dea/2010': 'GammaHydroxybutyricAcid',
+ 'drug/dea/2012': 'FDAApprovedGammaHydroxybutyricAcidPreparations',
+ 'drug/dea/2100': 'BarbituricAcidDerivativeOrSalt',
+ 'drug/dea/2125': 'Amobarbital',
+ 'drug/dea/2165': 'Butalbital',
+ 'drug/dea/2270': 'Pentobarbital', # Intentionally duplicated
+ 'drug/dea/2285': 'Phenobarbital', # 
+ 'drug/dea/2315': 'Secobarbital',
+ 'drug/dea/2765': 'Diazepam',
+ 'drug/dea/2783': 'Zolpidem',
+ 'drug/dea/2885': 'Lorazepam',
+ 'drug/dea/4000': 'AnabolicSteroids',
+ 'drug/dea/4187': 'Testosterone',
+ 'drug/dea/7285': 'Ketamine',
+ 'drug/dea/7315D': 'Lysergide',
+ 'drug/dea/7365': 'MarketableOralDronabinol',
+ 'drug/dea/7369': 'DronabinolGelCapsule',
+ 'drug/dea/7370': 'Tetrahydrocannabinol',
+ 'drug/dea/7377': 'Cannabicyclol',
+ 'drug/dea/7379': 'Nabilone',
+ 'drug/dea/7381': 'Mescaline',
+ 'drug/dea/7400': '34Methylenedioxyamphetamine',
+ 'drug/dea/7431': '5MethoxyNNDimethyltryptamine',
+ 'drug/dea/7433': 'Bufotenine',
+ 'drug/dea/7437': 'Psilocybin',
+ 'drug/dea/7438': 'Psilocin',
+ 'drug/dea/7455': 'PCE',
+ 'drug/dea/7471': 'Phencyclidine',
+ 'drug/dea/7540': 'Methylone',
+ 'drug/dea/9010': 'Alphaprodine',
+ 'drug/dea/9020': 'Anileridine',
+ 'drug/dea/9041L': 'Cocaine',
+ 'drug/dea/9046': 'Norcocaine',
+ 'drug/dea/9050': 'Codeine',
+ 'drug/dea/9056': 'EtorphineExceptHCl',
+ 'drug/dea/9064': 'Buprenorphine',
+ 'drug/dea/9120': 'Dihydrocodeine',
+ 'drug/dea/9143': 'Oxycodone',
+ 'drug/dea/9150': 'Hydromorphone',
+ 'drug/dea/9168': 'Difenoxin',
+ 'drug/dea/9170': 'Diphenoxylate',
+ 'drug/dea/9180L': 'Ecgonine',
+ 'drug/dea/9190': 'Ethylmorphine',
+ 'drug/dea/9193': 'Hydrocodone',
+ 'drug/dea/9200': 'Heroin',
+ 'drug/dea/9220L': 'Levorphanol',
+ 'drug/dea/9230': 'Pethidine',
+ 'drug/dea/9250B': 'Methadone',
+ 'drug/dea/9273D': 'BulkDextropropoxyphene',
+ 'drug/dea/9300': 'Morphine',
+ 'drug/dea/9313': 'Normorphine',
+ 'drug/dea/9333': 'Thebaine',
+ 'drug/dea/9411': 'Naloxone',
+ 'drug/dea/9600': 'RawOpium',
+ 'drug/dea/9630': 'TincuredOpium',
+ 'drug/dea/9639': 'PowderedOpium',
+ 'drug/dea/9652': 'Oxymorphone',
+ 'drug/dea/9655': 'Paregoric',
+ 'drug/dea/9665': '14Hydroxycodeinone',
+ 'drug/dea/9668': 'Noroxymorphone',
+ 'drug/dea/9670': 'PoppyStrawConcentrate',
+ 'drug/dea/9737': 'Alfentanil',
+ 'drug/dea/9739': 'Remifentanil',
+ 'drug/dea/9740': 'Sufentanil',
+ 'drug/dea/9743': 'Carfentanil',
+ 'drug/dea/9780': 'Tapentadol',
+ 'drug/dea/9801': 'Fentanyl',
+}
+
+# Exceptionally long and confusing cause of death names are manually renamed.
+MANUAL_CAUSE_OF_DEATH_RENAMINGS = {
+  'ICD10/D50-D89': 'DiseasesOfBloodAndBloodFormingOrgansAndImmuneDisorders',
+  'ICD10/R00-R99': 'AbnormalNotClassfied',
+  'ICD10/U00-U99': 'SpecialCases',
+  'ICD10/V01-Y89': 'ExternalCauses'
+}
+
+# List of properties to perform a numerical quantity remap on  
+NUMERICAL_QUANTITY_PROPERTIES_TO_REMAP = ['income', 'age', 'householderAge', 'homeValue', 'dateBuilt', 'grossRent', 'numberOfRooms', 'numberOfRooms', 'householdSize', 'numberOfVehicles', 'propertyTax']
+
+# Regex ules to apply to numerical quantity remap
+REGEX_NUMERICAL_QUANTITY_RENAMINGS = [
+  # [A-Za-z]+[0-9]+Onwards -> [0-9]+Onwards[A-Za-z]+
+  (re.compile(r"^([A-Za-z]+)([0-9]+)Onwards$"), lambda match: match.group(2) + "OrMore" + match.group(1)),
+
+  # [A-Za-z]+UpTo[0-9]+ -> UpTo[0-9]+[A-Za-z]+
+  (re.compile(r"^([A-Za-z]+)Upto([0-9]+)$"), lambda match: "Upto" + match.group(2) + match.group(1)),
+
+  # [A-Za-z]+[0-9]+To[0-9]+-> [0-9]+To[0-9]+[A-Za-z]+
+  (re.compile(r"^([A-Za-z]+)([0-9]+)To([0-9]+)$"), lambda match: match.group(2) + "To" + match.group(3) + match.group(1)),
+
+  # [A-Za-z]+[0-9]+ -> [0-9]+[A-Za-z]+
+  (re.compile(r"^([A-Za-z]+)([0-9]+)$"), lambda match: match.group(2) + match.group(1))
+]

--- a/stat_var_renaming/stat_var_renaming_test.py
+++ b/stat_var_renaming/stat_var_renaming_test.py
@@ -1,0 +1,62 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+  This file contains various tests for methods used in the Statiistical variable renaming.
+
+  TODO finish test coverage
+"""
+
+from stat_var_renaming import *
+import unittest
+
+def test_with_remap(test_cases, function):
+    remapper = remap_numerical_quantities({})
+
+    for prop, constraint, expected in test_cases:
+        if remapper[prop][0](prop, constraint) != expected:
+            return False
+
+    return True
+
+class TestHelperMethods(unittest.TestCase):
+    def test_standard_name_remapper(self):
+        self.assertEqual(standard_name_remapper("Some,list,Of,stuff"), 'SomeListOfStuff')
+        self.assertEqual(standard_name_remapper("Google small-query"), 'GoogleSmallQuery')
+        self.assertEqual(standard_name_remapper("Bells and Whistles"), 'BellsWhistles')
+
+class TestPropertyRemappers(unittest.TestCase):
+    def test_regex_remapping(self):
+        test_cases = [
+            ('householderAge', 'Years25To44', '25To44Years'),
+            ('income', 'USDollar100000To124999', '100000To124999USDollar'),
+            ('age', 'Years15Onwards', '15OrMoreYears'),
+            ('age', 'YearsUpto1', 'Upto1Years'),
+            ('detailedLevelOfSchool', 'EnrolledInGrade1', 'EnrolledInGrade1')
+        ]
+
+        self.assertTrue(test_with_remap(test_cases, remap_numerical_quantities))
+
+    def test_naics_remapping(self):
+        test_cases = [
+            ('naics', 'Years25To44', '25To44Years'),
+            ('income', 'USDollar100000To124999', '100000To124999USDollar'),
+            ('age', 'Years15Onwards', '15OrMoreYears'),
+            ('age', 'YearsUpto1', 'Upto1Years'),
+            ('detailedLevelOfSchool', 'EnrolledInGrade1', 'EnrolledInGrade1')
+        ]
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently most Statistical Variables(e.g. the count of males with diabetes) have randomly generated IDs. As end users are starting to use the Google Sheets or Python APIs, they will use these statistical variable names to pull information. A small subset of these have manually created Ids (TotalPopulation), but a robust method was needed for generating IDs for the hundreds of statistical variables present in the Knowledge Graph. 