### PR TITLE
if no data, display dash instead of 0

### DIFF
--- a/covid19-dashboard/src/CumulativePanel.tsx
+++ b/covid19-dashboard/src/CumulativePanel.tsx
@@ -28,7 +28,13 @@ export default function CumulativePanel(props: CountPanelPropsType) {
     <div className={'panel count-panel'}>
       {props.textToValue.map((obj, index) => {
         const title = obj.title;
-        const value = numberWithCommas(obj.value);
+
+        // If value is nullish (including 0), display a dash.
+        let value = "-"
+        if (obj.value) {
+          value = numberWithCommas(obj.value);
+        }
+
         const color = obj.color ? Colors(obj.color) : 'grey';
         return (
           <div className={'column'} key={index} style={{width: pctWidthPerRow}}>


### PR DESCRIPTION
If there is no data, display a dash instead of 0 on the cumulative panel.

<img width="1627" alt="Screen Shot 2020-09-21 at 5 04 38 PM" src="https://user-images.githubusercontent.com/11444894/93821431-8cd8cb00-fc2c-11ea-9ead-4836812c452c.png">
