### PR TITLE
COVID19 dashboard: Install Numeral dependency

### DIFF
--- a/covid19-dashboard/package-lock.json
+++ b/covid19-dashboard/package-lock.json
@@ -2218,6 +2218,12 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/numeral": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-0.0.28.tgz",
+      "integrity": "sha512-Sjsy10w6XFHDktJJdXzBJmoondAKW+LcGpRFH+9+zXEDj0cOH8BxJuZA9vUDSMAzU1YRJlsPKmZEEiTYDlICLw==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -11956,6 +11962,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+    },
+    "numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
     },
     "nwsapi": {
       "version": "2.2.0",

--- a/covid19-dashboard/package.json
+++ b/covid19-dashboard/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "^4.5.1",
     "dayjs": "^1.8.34",
     "lodash": "^4.17.19",
+    "numeral": "^2.0.6",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",
@@ -43,22 +44,23 @@
     ]
   },
   "devDependencies": {
-    "@types/history": "^4.7.7",
-    "@types/node": "^14.11.2",
-    "@types/react-router-dom": "^5.1.5",
-    "@types/recharts": "^1.8.14",
-    "gts": "^3.0.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "@testing-library/user-event": "^12.1.3",
+    "@types/history": "^4.7.7",
     "@types/lodash": "^4.14.161",
+    "@types/node": "^14.11.2",
+    "@types/numeral": "0.0.28",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
-    "eslint": "^6.6.0",
+    "@types/react-router-dom": "^5.1.5",
+    "@types/recharts": "^1.8.14",
     "@typescript-eslint/eslint-plugin": "4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
-    "typescript": "^4.0.3",
+    "eslint": "^6.6.0",
+    "gts": "^3.0.0",
     "sass": "^1.26.10",
-    "scss": "^0.2.4"
+    "scss": "^0.2.4",
+    "typescript": "^4.0.3"
   }
 }


### PR DESCRIPTION
I didn't push the package.json with Numeral on the last PR, this PR simply adds this missing dependency to package.json
**Script reordered package.json, but the list of packages is the same.**

This is the library in charge if prettifying numbers such as 1K, 1.2T, etc...