### PR TITLE
Set project automatically when deploying COVID19 to app engine

### DIFF
--- a/covid19-dashboard/deploy_gcloud.sh
+++ b/covid19-dashboard/deploy_gcloud.sh
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Change GOOGLE_CLOUD_PROJECT if deploying to diffrent project.
+# Change variable if deploying to different project.
 export GOOGLE_CLOUD_PROJECT="datcom-website"
+
+# Set the project on gcloud.
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 # App Engine only understands static files, so build these files.
 npm install


### PR DESCRIPTION
Configure project when deploying to "datcom-website", although this will change when the new project is created.
I will create a separate PR that updates the project to "datcom-tools" in all the documentation.