### PR TITLE
MCF Browser: remove missing property value error check

### DIFF
--- a/mcf-browser/src/back-end/parse-mcf.js
+++ b/mcf-browser/src/back-end/parse-mcf.js
@@ -135,7 +135,7 @@ class ParseMcf {
             [this.lineNum, this.line, ERROR_MESSAGES['curNode-ns']]);
         return;
       }
-    } else{
+    } else {
       // handle case: Node: localRef, which means parsedValues[0]==='localRef'
       nodeRef = parsedValues[0];
       ns = '';
@@ -145,7 +145,7 @@ class ParseMcf {
     this.curNode = Node.getNode(nodeId);
 
     if (ns === 'dcid:') {
-      if(!this.curNode.setDCID(nodeRef)){
+      if (!this.curNode.setDCID(nodeRef)) {
         this.errors.push([this.lineNum, this.line, ERROR_MESSAGES['setDCID']]);
         return;
       }
@@ -245,8 +245,7 @@ class ParseMcf {
       return;
     }
     if (!propValues) {
-      this.errors.push(
-          [this.lineNum, this.line, ERROR_MESSAGES['parse-noValues']]);
+      // if there is a missing property value, do not return error
       return;
     }
 

--- a/mcf-browser/src/back-end/test/parse-mcf.test.js
+++ b/mcf-browser/src/back-end/test/parse-mcf.test.js
@@ -25,13 +25,14 @@ test('testing constructor. prov property', () => {
 });
 
 test('testing parsePropValues: should output property values', () => {
-  const rawVals = 'val1, l:localNodeId, "GO:BioIdTextVal",schema:remoteNodeId,'+
-    ' "A, B", "B, C,D"';
+  const rawVals =
+      'val1, l:localNodeId, "GO:BioIdTextVal",schema:remoteNodeId,' +
+      ' "A, B", "B, C,D"';
   const expectedParsedVals = [
     'val1',
-    {'ns' : 'l', 'ref' : 'localNodeId'},
+    {'ns': 'l', 'ref': 'localNodeId'},
     'GO:BioIdTextVal',
-    {'ns' : 'schema', 'ref' : 'remoteNodeId'},
+    {'ns': 'schema', 'ref': 'remoteNodeId'},
     'A, B',
     'B, C,D',
   ];
@@ -40,23 +41,22 @@ test('testing parsePropValues: should output property values', () => {
   mcfParser.lineNum = 0;
   const parsedVals = mcfParser.parsePropValues(rawVals, 0);
   expect(parsedVals).toStrictEqual(expectedParsedVals);
-
 });
 
 test('testing setCurNode', () => {
   const fileName = 'fileName';
   const mcfParser = new ParseMcf(fileName);
 
-  const noNameSpaceParsedVal = [ 'localNoNameSpaceId' ];
+  const noNameSpaceParsedVal = ['localNoNameSpaceId'];
   const noNameSpaceExpectedNode = new Node('l:' + noNameSpaceParsedVal[0]);
   mcfParser.setCurNode(noNameSpaceParsedVal);
   expect(mcfParser.curNode).toStrictEqual(noNameSpaceExpectedNode);
 
   const remoteNameSpaceParsedVal =
-      [ {'ns' : 'dcid', 'ref' : 'remoteNamespaceId'} ];
+      [{'ns': 'dcid', 'ref': 'remoteNamespaceId'}];
 
   const remoteNameSpaceExpectedNode =
-      new Node('l:dcid:'+remoteNameSpaceParsedVal[0]['ref']);
+      new Node('l:dcid:' + remoteNameSpaceParsedVal[0]['ref']);
   remoteNameSpaceExpectedNode.setDCID(remoteNameSpaceParsedVal[0]['ref']);
   mcfParser.setCurNode(remoteNameSpaceParsedVal);
   expect(mcfParser.curNode).toStrictEqual(remoteNameSpaceExpectedNode);
@@ -67,7 +67,7 @@ test('testing setCurNodeDCID', () => {
 
   const mcfParser = new ParseMcf(fileName);
   const localId = 'l:testSrcId';
-  const parsedValue = [ 'bio/test' ];
+  const parsedValue = ['bio/test'];
   mcfParser.curNode = new Node(localId);
   expect(mcfParser.curNode.localId).toBe(localId);
   expect(mcfParser.curNode.dcid).toBe(null);
@@ -76,7 +76,6 @@ test('testing setCurNodeDCID', () => {
 
   expect(mcfParser.curNode.localId).toBe(localId);
   expect(mcfParser.curNode.dcid).toBe('bio/test');
-
 });
 
 test('testing string values with createAssertionsFromParsedValues', () => {
@@ -88,7 +87,7 @@ test('testing string values with createAssertionsFromParsedValues', () => {
   mcfParser.curNode = new Node(localId);
   mcfParser.curNode.setDCID(remoteId);
   const propLabel = 'stringVal';
-  const parsedValues = [ 'val1', '"GO:bioTextId"' ];
+  const parsedValues = ['val1', '"GO:bioTextId"'];
 
   mcfParser.createAssertionsFromParsedValues(propLabel, parsedValues);
   const assertions = mcfParser.curNode.assertions;
@@ -96,8 +95,8 @@ test('testing string values with createAssertionsFromParsedValues', () => {
   const assertionToJSON = (assertion) => {
     const {property, target, provenance} = assertion;
     return {
-      'srclocalId' : assertion.src.localId,
-      'srcDCID' : assertion.src.dcid,
+      'srclocalId': assertion.src.localId,
+      'srcDCID': assertion.src.dcid,
       property,
       target,
       provenance,
@@ -107,11 +106,11 @@ test('testing string values with createAssertionsFromParsedValues', () => {
   // note assertions are returned backwards due to nature of linked list
   const assertion1 = assertionToJSON(assertions[0]);
   const expectedAssertion = {
-    'srcDCID' : remoteId,
-    'srclocalId' : localId,
-    'property' : propLabel,
-    'target' : 'val1',
-    'provenance' : fileName,
+    'srcDCID': remoteId,
+    'srclocalId': localId,
+    'property': propLabel,
+    'target': 'val1',
+    'provenance': fileName,
   };
   expect(assertion1).toEqual(expectedAssertion);
   const assertion2 = assertionToJSON(assertions[1]);
@@ -127,8 +126,8 @@ test('testing node values with createAssertionsFromParsedValues', () => {
 
   const propLabel = 'nodeVal';
   const parsedValues = [
-    {'ns' : 'l', 'ref' : 'localId'},
-    {'ns' : 'dcs', 'ref' : 'remoteId'},
+    {'ns': 'l', 'ref': 'localId'},
+    {'ns': 'dcs', 'ref': 'remoteId'},
   ];
 
   mcfParser.createAssertionsFromParsedValues(propLabel, parsedValues);
@@ -137,10 +136,10 @@ test('testing node values with createAssertionsFromParsedValues', () => {
   const assertionToJSON = (assertion) => {
     const {property, provenance} = assertion;
     return {
-      'srclocalId' : assertion.src.localId,
-      'srcDCID' : assertion.src.dcid,
-      'targetlocalId' : assertion.target.localId,
-      'targetDCID' : assertion.target.dcid,
+      'srclocalId': assertion.src.localId,
+      'srcDCID': assertion.src.dcid,
+      'targetlocalId': assertion.target.localId,
+      'targetDCID': assertion.target.dcid,
       property,
       provenance,
     };
@@ -149,12 +148,12 @@ test('testing node values with createAssertionsFromParsedValues', () => {
   // note assertions are returned backwards due to nature of linked list
   const assertion1 = assertionToJSON(assertions[0]);
   const expectedAssertion = {
-    'srclocalId' : localId,
-    'srcDCID' : null,
-    'targetlocalId' : 'l:localId',
-    'targetDCID' : null,
-    'property' : propLabel,
-    'provenance' : fileName,
+    'srclocalId': localId,
+    'srcDCID': null,
+    'targetlocalId': 'l:localId',
+    'targetDCID': null,
+    'property': propLabel,
+    'provenance': fileName,
   };
   expect(assertion1).toEqual(expectedAssertion);
   const target1 = assertions[0]['target'];
@@ -185,8 +184,6 @@ test('testing parseLine: ', () => {
   mcfParser.parseLine(testStr3);
   expect(mcfParser.curNode.localId).toBe('l:localSubjId');
   expect(mcfParser.curNode.dcid).toBe('remoteId');
-
-
 });
 
 const mcfStr = `
@@ -206,8 +203,8 @@ test('testing ParseMcfStr: ', () => {
   const assertionToJSON = (assertion) => {
     const {property, provenance} = assertion;
     const json = {
-      'srclocalId' : assertion.src.localId,
-      'srcDCID' : assertion.src.dcid,
+      'srclocalId': assertion.src.localId,
+      'srcDCID': assertion.src.dcid,
       property,
       provenance,
     };
@@ -234,49 +231,49 @@ test('testing ParseMcfStr: ', () => {
 
   for (const assert of obsAsserts) {
     const expectedJSON = {
-      'srclocalId' : obsNode.localId,
-      'srcDCID' : obsNode.dcid,
-      'provenance' : fileName,
+      'srclocalId': obsNode.localId,
+      'srcDCID': obsNode.dcid,
+      'provenance': fileName,
     };
 
     const assertJSON = assertionToJSON(assert);
     switch (assert.property) {
-    case 'remoteNodeProp':
-      expectedJSON['property'] = 'remoteNodeProp';
-      expectedJSON['targetlocalId'] = null;
-      expectedJSON['targetDCID'] = 'StatVarObservation';
-      expect(assert.target.invAssertions[0]).toStrictEqual(assert);
-      expect(assertJSON).toStrictEqual(expectedJSON);
-      break;
-    case 'localNodeProp':
-      expectedJSON['property'] = 'localNodeProp';
+      case 'remoteNodeProp':
+        expectedJSON['property'] = 'remoteNodeProp';
+        expectedJSON['targetlocalId'] = null;
+        expectedJSON['targetDCID'] = 'StatVarObservation';
+        expect(assert.target.invAssertions[0]).toStrictEqual(assert);
+        expect(assertJSON).toStrictEqual(expectedJSON);
+        break;
+      case 'localNodeProp':
+        expectedJSON['property'] = 'localNodeProp';
 
-      expectedJSON['targetlocalId'] = 'l:LocalIndiaNode';
-      expectedJSON['targetDCID'] = 'country/IND';
-      expect(assert.target.invAssertions[0]).toStrictEqual(assert);
-      expect(assertJSON).toStrictEqual(expectedJSON);
-      break;
+        expectedJSON['targetlocalId'] = 'l:LocalIndiaNode';
+        expectedJSON['targetDCID'] = 'country/IND';
+        expect(assert.target.invAssertions[0]).toStrictEqual(assert);
+        expect(assertJSON).toStrictEqual(expectedJSON);
+        break;
 
-    case 'stringProp':
-      expectedJSON['property'] = 'stringProp';
+      case 'stringProp':
+        expectedJSON['property'] = 'stringProp';
 
-      expectedJSON['target'] = '2020-08-01';
-      expect(assertJSON).toStrictEqual(expectedJSON);
-      break;
+        expectedJSON['target'] = '2020-08-01';
+        expect(assertJSON).toStrictEqual(expectedJSON);
+        break;
 
-    case 'numProp':
-      expectedJSON['property'] = 'numProp';
+      case 'numProp':
+        expectedJSON['property'] = 'numProp';
 
-      expectedJSON['target'] = '10000';
-      expect(assertJSON).toStrictEqual(expectedJSON);
-      break;
-    case 'bioID':
-      expectedJSON['property'] = 'bioID';
-      expectedJSON['target'] = 'GO:bioTextId';
-      expect(assertJSON).toStrictEqual(expectedJSON);
-      break;
-    default:
-      throw new Error('Unexpected assertion: ' + assert);
+        expectedJSON['target'] = '10000';
+        expect(assertJSON).toStrictEqual(expectedJSON);
+        break;
+      case 'bioID':
+        expectedJSON['property'] = 'bioID';
+        expectedJSON['target'] = 'GO:bioTextId';
+        expect(assertJSON).toStrictEqual(expectedJSON);
+        break;
+      default:
+        throw new Error('Unexpected assertion: ' + assert);
     }
   }
   expect(obsNode.invAssertions).toStrictEqual([]);
@@ -291,16 +288,16 @@ test('testing ParseMcfStr: ', () => {
   expect(indiaInvAsserts.length).toStrictEqual(1);
 
   const invAssertJSON = {
-    'src' : indiaInvAsserts[0].src,
-    'prop' : indiaInvAsserts[0].property,
-    'prov' : indiaInvAsserts[0].provenance,
-    'target' : indiaInvAsserts[0].target,
+    'src': indiaInvAsserts[0].src,
+    'prop': indiaInvAsserts[0].property,
+    'prov': indiaInvAsserts[0].provenance,
+    'target': indiaInvAsserts[0].target,
   };
   const expectedInvAssert = {
-    'src' : obsNode,
-    'prop' : 'localNodeProp',
-    'prov' : fileName,
-    'target' : indiaNode,
+    'src': obsNode,
+    'prop': 'localNodeProp',
+    'prov': fileName,
+    'target': indiaNode,
   };
   expect(invAssertJSON).toStrictEqual(expectedInvAssert);
 });
@@ -309,20 +306,20 @@ test('testing errors: ', () => {
   const fileName = 'fileName.mcf';
   const mcfParser = new ParseMcf(fileName);
 
-  mcfParser.setCurNode([ 'localId1', 'localId2' ]); // #1
-  mcfParser.setCurNode([{'ns':'invalid', 'ref':  'localId1'}]) // #2
-  mcfParser.createAssertionsFromParsedValues(['val']) // #3
+  mcfParser.setCurNode(['localId1', 'localId2']); // #1
+  mcfParser.setCurNode([{'ns': 'invalid', 'ref': 'localId1'}]); // #2
+  mcfParser.createAssertionsFromParsedValues(['val']); // #3
 
-  mcfParser.setCurNode([ 'localId1' ]);
-  mcfParser.setCurNodeDCID(['dcid1', 'dcid2']) // #4
-  mcfParser.setCurNodeDCID([{'ns':'dcid', 'ref':'remote'}]) // #5
+  mcfParser.setCurNode(['localId1']);
+  mcfParser.setCurNodeDCID(['dcid1', 'dcid2']); // #4
+  mcfParser.setCurNodeDCID([{'ns': 'dcid', 'ref': 'remote'}]); // #5
 
-  mcfParser.setCurNodeDCID(['dcid1'])
-  mcfParser.setCurNodeDCID(['dcid2']) // #6
+  mcfParser.setCurNodeDCID(['dcid1']);
+  mcfParser.setCurNodeDCID(['dcid2']); // #6
 
-  mcfParser.parseLine('prop') // #7
-  mcfParser.parseLine(':val') // #8
-  mcfParser.parseLine('val:') // #9
+  mcfParser.parseLine('prop'); // #7
+  mcfParser.parseLine(':val'); // #8
+  mcfParser.parseLine('val:'); // #9
 
   expect(mcfParser.errors).toEqual([
     [-1, undefined, ERROR_MESSAGES['curNode-length']], // #1
@@ -333,7 +330,5 @@ test('testing errors: ', () => {
     [-1, undefined, ERROR_MESSAGES['setDCID']], // #6
     [-1, undefined, ERROR_MESSAGES['parse-noColon']], // #7
     [-1, undefined, ERROR_MESSAGES['parse-noLabel']], // #8
-    [-1, undefined, ERROR_MESSAGES['parse-noValues']], // #9
-   ]);
-
+  ]);
 });

--- a/mcf-browser/src/back-end/utils.js
+++ b/mcf-browser/src/back-end/utils.js
@@ -33,7 +33,6 @@ const ERROR_MESSAGES =
       'assert-noCur': 'current node must be set before declaring properties',
       'parse-noColon': 'missing \':\', incorrect mcf triple format',
       'parse-noLabel': 'missing property label',
-      'parse-noValues': 'missing property value',
     };
 
 /**


### PR DESCRIPTION
A missing property value is no longer classified as an error. For example in this mcf:

Node: localId
property1:
property2: "value"

it would be okay for property1 to have a missing value. This line will be skipped in parse-mcf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/tools/81)
<!-- Reviewable:end -->
