### PR TITLE
Reduce nodes in datcom-store project to 298.

### DIFF
--- a/bigtable_automation/gcf/bt_trigger.go
+++ b/bigtable_automation/gcf/bt_trigger.go
@@ -93,7 +93,7 @@ var (
 			dataflowTemplate: "gs://datcom-templates/templates/csv_to_bt",
 			baseBTInstance:   "prophet-cache",
 			baseBTClusters:   []string{"prophet-cache-c1"},
-			baseBTNodesHigh:  300,
+			baseBTNodesHigh:  298,
 			baseBTNodesLow:   5,
 			branchBTInstance: "prophet-branch-cache",
 			dataBucket:       "datcom-store",


### PR DESCRIPTION
The max BT node limit for datcom-store is 300. Of which 2 are reserved for branch cluster, so reduce the main cluster's limit by 2.