### PR TITLE
BT writes: Ensure empty values get written

### DIFF
--- a/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CsvImport.java
+++ b/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CsvImport.java
@@ -42,7 +42,8 @@ public class CsvImport {
       try {
         // TODO: Pass header as congfiguration.
         String[] headers = new String[] {"value"};
-        String[] values = c.element().split(",");
+        // Include trailing empty strings (to handle empty values).
+        String[] values = c.element().split(",", -1);
         Preconditions.checkArgument(headers.length == (values.length-1)); // first element of values is key for BT row.
 
         byte[] rowkey = Bytes.toBytes(values[0]);


### PR DESCRIPTION
In case the value in the CSV is empty, the current logic throws an exception:

![image](https://user-images.githubusercontent.com/4375037/150560972-ed3b7f4c-5b27-4b70-9e73-de62bdf88c00.png)

Tested the change by running it on a test CSV that failed previously ([here](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2022-01-21_06_43_26-14894128620723362307?project=google.com:datcom-store-dev)).