### PR TITLE
Improve BT automation

### DIFF
--- a/bigtable_automation/gcf/README.md
+++ b/bigtable_automation/gcf/README.md
@@ -82,8 +82,12 @@ go build main.go
 
 ## Deployment
 
-After validating the change in test environment, deploy to PROD by manually
-copying over the cloud function to
-[prophet-cache-trigger](https://pantheon.corp.google.com/functions/details/us-central1/prophet-cache-trigger?organizationId=433637338589&project=datcom-store&tab=source).
+After validating the change in test environment, deploy to PROD by running:
 
-TODO: Improve deployment process.
+```
+./deploy.sh
+```
+
+When this completes, look at the
+[prophet-cache-trigger](https://pantheon.corp.google.com/functions/details/us-central1/prophet-cache-trigger?organizationId=433637338589&project=datcom-store&tab=source)
+on GCP console to version.

--- a/bigtable_automation/gcf/bt_trigger.go
+++ b/bigtable_automation/gcf/bt_trigger.go
@@ -48,6 +48,9 @@ const (
 	launchedFile = "launched.txt"
 	// Completed: written by dataflow to mark completion of BT import.
 	completedFile = "completed.txt"
+
+	// Default region
+	region = "us-central1"
 )
 
 type environment struct {
@@ -170,6 +173,7 @@ func launchDataflowJob(ctx context.Context, env *environment, btInstance, cacheT
 			"bigtableInstanceId": btInstance,
 			"bigtableTableId":    tableID,
 			"bigtableProjectId":  env.btProjectID,
+			"region": region,
 		},
 	}
 

--- a/bigtable_automation/gcf/deploy.sh
+++ b/bigtable_automation/gcf/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Prepare directory
+mkdir -p /tmp/deploy_bt_gcf
+cp bt_trigger.go go.mod /tmp/deploy_bt_gcf
+cd /tmp/deploy_bt_gcf
+
+gcloud config set project datcom-store
+gcloud functions deploy prophet-cache-trigger \
+  --region 'us-central1' \
+  --entry-point BTImportController \
+  --runtime go113 \
+  --trigger-bucket datcom-control

--- a/bigtable_automation/gcf/go.mod
+++ b/bigtable_automation/gcf/go.mod
@@ -1,6 +1,6 @@
-module btcachegeneration
+module example.com/btcachegeneration
 
-go 1.15
+go 1.13
 
 require (
 	cloud.google.com/go/bigtable v1.6.0

--- a/bigtable_automation/java/dataflow/README.md
+++ b/bigtable_automation/java/dataflow/README.md
@@ -62,7 +62,7 @@ After validating the change in test environment, deploy it to PROD template by
 running the following command.
 
 ```
-mvn compile exec:java -Dexec.mainClass=org.datacommons.dataflow.CsvImport -Dexec.args="--runner=DataflowRunner --project=datcom-store --stagingLocation=gs://datcom-templates/staging --templateLocation=gs://datcom-templates/templates/csv_to_bt --region=us-central1"
+mvn compile exec:java -Dexec.mainClass=org.datacommons.dataflow.CsvImport -Dexec.args="--runner=DataflowRunner --project=datcom-store --stagingLocation=gs://datcom-templates/staging --templateLocation=gs://datcom-templates/templates/csv_to_bt --region=us-central1 --usePublicIps=false"
 ```
 
 NOTE: Running this may throw an exception, but as long as it says `BUILD

--- a/bigtable_automation/java/dataflow/test.sh
+++ b/bigtable_automation/java/dataflow/test.sh
@@ -4,7 +4,7 @@ set -x
 
 if [[ "$1" == "deploy" ]]; then
 
-  mvn compile exec:java -Dexec.mainClass=org.datacommons.dataflow.CsvImport -Dexec.args="--runner=DataflowRunner --project=google.com:datcom-store-dev --stagingLocation=gs://datcom-dataflow-templates/test_staging --templateLocation=gs://datcom-dataflow-templates/templates/csv_to_bt_test --region=us-central1"
+  mvn compile exec:java -Dexec.mainClass=org.datacommons.dataflow.CsvImport -Dexec.args="--runner=DataflowRunner --project=google.com:datcom-store-dev --stagingLocation=gs://datcom-dataflow-templates/test_staging --templateLocation=gs://datcom-dataflow-templates/templates/csv_to_bt_test --region=us-central1 --usePublicIps=false"
 
 elif [[ "$1" == "run-cache" ]]; then
 
@@ -21,6 +21,7 @@ elif [[ "$1" == "run-cache" ]]; then
 
   gcloud dataflow jobs run test-csv2bt-${TABLE} \
     --gcs-location gs://datcom-dataflow-templates/templates/csv_to_bt_test \
+    --region us-central1 \
     --parameters inputFile=gs://datcom-store/${TABLE}/cache.csv*,completionFile=gs://automation_control_test/finished-${TABLE}.txt,bigtableInstanceId=prophet-test,bigtableTableId=${TABLE},bigtableProjectId=google.com:datcom-store-dev
 
 elif [[ "$1" == "run-csv" ]]; then


### PR DESCRIPTION
List of changes:

1. Set usePublicIps=false.  This required enabling Private Network in us-central1 subnet (screenshot below).  I validated it by running the `test.sh` tool, but was somewhat puzzled to not find the usePublicIps option listed on the [job page](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2022-02-03_15_52_03-15865834863613240020?project=google.com:datcom-store-dev).  However, I verified that the running VMs were using private IP (screenshot below).

2. Pass --region='us-central1' explicitly (it seems to be an upcoming required arg), and also given the private network requirement, it seems better to set.

3. Add a tool to deploy the Cloud Function to prod.

![image](https://user-images.githubusercontent.com/4375037/152451360-318eeeb9-8c5c-484b-aef5-370b3289faa2.png)

![image](https://user-images.githubusercontent.com/4375037/152451506-d8a99e1d-8dd8-4817-9156-1e1bec43e90b.png)
