### PR TITLE
Remove deprecated import repo npm cloudbuild

### DIFF
--- a/periodic_builds/builds.txt
+++ b/periodic_builds/builds.txt
@@ -1,5 +1,4 @@
 import/build/cloudbuild.java.yaml
-import/build/cloudbuild.npm.yaml
 data/cloudbuild.go.yaml
 data/cloudbuild.py.yaml
 mixer/build/ci/cloudbuild.test.yaml


### PR DESCRIPTION
See: https://github.com/datacommonsorg/import/commit/d995b5c52d2750cb8ec4b5cce564209edda18e02 (https://github.com/datacommonsorg/import/pull/175)

The `build/cloudbuild.npm.yaml` file has been removed from the import repo, so removing it from periodic builds.