### PR TITLE
Fix lint issues for MCF Browser

### DIFF
--- a/mcf-browser/.eslintignore
+++ b/mcf-browser/.eslintignore
@@ -1,0 +1,3 @@
+*.css
+
+src/back-end/test/test-strs.ts

--- a/mcf-browser/.eslintrc.json
+++ b/mcf-browser/.eslintrc.json
@@ -1,16 +1,17 @@
 {
-  "parser": "babel-eslint",
+  "parser": "@typescript-eslint/parser",
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "prettier",
+    "google",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
     "env": {
         "browser": true,
         "es2021": true
     },
-    "extends": [
-        "plugin:react/recommended",
-        "google",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/eslint-recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true
@@ -22,7 +23,10 @@
         "react"
     ],
     "rules": {
-      "no-unused-expressions": "off"
+      "no-unused-expressions": "off",
+      "@typescript-eslint/ban-types": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-var-requires": "off"
     },
     "settings": {
       "react": {

--- a/mcf-browser/package.json
+++ b/mcf-browser/package.json
@@ -28,7 +28,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint --fix src/*"
+    "lint": "eslint --fix src"
   },
   "browserslist": {
     "production": [

--- a/mcf-browser/src/FileEntry.tsx
+++ b/mcf-browser/src/FileEntry.tsx
@@ -34,41 +34,7 @@ interface FileEntryPropType {
    * Sets whether the dropdown on the home page for additonal file entries
    * should be displayed.
    */
-  toggle: Function;
-}
-
-interface FileEntryStateType{
-  /**
-   * Stores user's text entry in the first url entry box. This should be a url
-   * to either a MCF or TMCF file.
-   */
-  mcfTmcfUrl: string;
-  /**
-   * Stores user's text entry in the second url entry box. This should be a url
-   * to a CSV file.
-   */
-  csvUrl: string;
-}
-
-interface FileEntryPropType {
-  /**
-   * Passes a file list to be submitted to the back-end for parsing.
-   */
-  upload: Function;
-  /**
-   * Passes a list of urls to be retrieved, then passed to the back-end for
-   * parsing.
-   */
-  loadFiles: Function;
-  /**
-   * Return to the home page/reset to current hash stored in App state.
-   */
-  goToHome: Function;
-  /**
-   * Sets whether the dropdown on the home page for additonal file entries
-   * should be displayed.
-   */
-  toggle: Function;
+  toggle?: Function;
 }
 
 interface FileEntryStateType{
@@ -111,14 +77,18 @@ class FileEntry extends Component<FileEntryPropType, FileEntryStateType> {
         this.setState({csvUrl: '', mcfTmcfUrl: ''});
         // trigger hash to be set to fileHash
         this.props.goToHome();
-        this.props.toggle();
+        if (this.props.toggle) {
+          this.props.toggle();
+        }
       } else if (this.state.mcfTmcfUrl.split('.').pop() === 'tmcf' &&
           (this.state.csvUrl.split('.').pop() === 'csv') ) {
         await this.props.loadFiles([this.state.mcfTmcfUrl, this.state.csvUrl]);
         this.setState({csvUrl: '', mcfTmcfUrl: ''});
         // trigger hash to be set to fileHash
         this.props.goToHome();
-        this.props.toggle();
+        if (this.props.toggle) {
+          this.props.toggle();
+        }
       }
     }
   }
@@ -140,7 +110,9 @@ class FileEntry extends Component<FileEntryPropType, FileEntryStateType> {
             <input type="file" required multiple
               accept=".mcf" onChange={(event) => {
                 this.props.upload(Array.from(event.target.files as FileList));
-                this.props.toggle();
+                if (this.props.toggle) {
+                  this.props.toggle();
+                }
               }}/>
               Upload MCF
           </label>
@@ -150,7 +122,9 @@ class FileEntry extends Component<FileEntryPropType, FileEntryStateType> {
             <input type="file" required multiple
               accept=".tmcf,.csv" onChange={(event) => {
                 this.props.upload(Array.from(event.target.files as FileList));
-                this.props.toggle();
+                if (this.props.toggle) {
+                  this.props.toggle();
+                }
               }}/>
               Upload TMCF + CSV
           </label>

--- a/mcf-browser/src/Home.tsx
+++ b/mcf-browser/src/Home.tsx
@@ -33,7 +33,8 @@ interface HomePropType {
    */
   upload: Function;
   /**
-   * Passes a list of urls to be retrieved, then passed to the back-end for parsing.
+   * Passes a list of urls to be retrieved, then passed to the back-end
+   * for parsing.
    */
   loadFiles: Function;
   /**
@@ -54,12 +55,13 @@ interface HomePropType {
    */
   loading: boolean;
   /**
-   * IDs for nodes stored in App's state which are the subject nodes of triples from
-   * any parsed files.
+   * IDs for nodes stored in App's state which are the subject nodes of
+   * triples from any parsed files.
    */
   subjNodes: string[];
   /**
-   * Set id parameter in url to the given id. Used when user clicks a subject node to explore.
+   * Set id parameter in url to the given id. Used when user clicks a
+   * subject node to explore.
    */
   goToId: Function;
 }
@@ -108,7 +110,7 @@ class Home extends Component<HomePropType, HomeStateType> {
             <FileEntry upload={this.props.upload}
               loadFiles={this.props.loadFiles}
               goToHome={this.props.goToHome}
-              toggle={() => {}}/>
+            />
           </div>
         </div>
       );

--- a/mcf-browser/src/TriplesTable.tsx
+++ b/mcf-browser/src/TriplesTable.tsx
@@ -52,7 +52,10 @@ interface TriplesTableStateType{
 }
 
 /** Displays all given assertions as a table of triples. */
-export class TriplesTable extends Component<TriplesTablePropType, TriplesTableStateType> {
+export class TriplesTable extends Component<
+  TriplesTablePropType,
+  TriplesTableStateType
+> {
   /** Constructor for class, sets initial state
    *
    * @param {Object} props the props passed in by parent component
@@ -93,7 +96,9 @@ export class TriplesTable extends Component<TriplesTablePropType, TriplesTableSt
   */
   async getTargetCell(target: Node | string) {
     if (API.isNodeObj(target)) {
-      const elemClass: utils.ColorIndex = (await API.getElemClass(target as Node)) as utils.ColorIndex;
+      const elemClass: utils.ColorIndex = (await API.getElemClass(
+        target as Node,
+      )) as utils.ColorIndex;
       const nodeTarget = target as Node;
       return (
         <div>

--- a/mcf-browser/src/back-end/parse-mcf.ts
+++ b/mcf-browser/src/back-end/parse-mcf.ts
@@ -41,7 +41,7 @@ type ParseFileResponse = {
 
   /** A list of the ids of the subject nodes */
   localNodes: string[];
-}
+};
 
 /** Class responsible for parsing an mcf file. */
 class ParseMcf {
@@ -109,12 +109,18 @@ class ParseMcf {
       const namespace = propValue.split(':')[0].trim();
       if (namespace in NAMESPACES) {
         values.push({
-          'ns': namespace,
-          'ref': propValue.substring(propValue.indexOf(':') + 1).trim(),
+          ns: namespace,
+          ref: propValue.substring(propValue.indexOf(':') + 1).trim(),
         });
-      } else if (propValue.split(':').length > 1 &&
-                 !namespace.startsWith('"')) {
-        this.errors.push([this.lineNum.toString(), this.line as string, 'unrecognized namespace']);
+      } else if (
+        propValue.split(':').length > 1 &&
+        !namespace.startsWith('"')
+      ) {
+        this.errors.push([
+          this.lineNum.toString(),
+          this.line as string,
+          'unrecognized namespace',
+        ]);
         return [];
       } else {
         // push property value with surrounding double quotes trimmed
@@ -137,8 +143,11 @@ class ParseMcf {
    */
   setCurNode(parsedValues: Object[]) {
     if (parsedValues.length !== 1) {
-      this.errors.push(
-          [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.CUR_NODE_LENGTH]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.CUR_NODE_LENGTH,
+      ]);
       return;
     }
 
@@ -154,9 +163,11 @@ class ParseMcf {
         ns = ns + ':';
         nodeRef = firstValue['ref'];
       } else {
-        this.errors.push(
-            [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.CUR_NODE_NS]);
-        return;
+        this.errors.push([
+          this.lineNum.toString(),
+          this.line as string,
+          ERROR_MESSAGES.CUR_NODE_NS,
+        ]);
       }
     } else {
       // handle case: Node: localRef, which means parsedValues[0]==='localRef'
@@ -169,7 +180,11 @@ class ParseMcf {
 
     if (ns === 'dcid:') {
       if (this.curNode && !this.curNode.setDCID(nodeRef)) {
-        this.errors.push([this.lineNum.toString(), this.line as string, ERROR_MESSAGES.SET_DCID]);
+        this.errors.push([
+          this.lineNum.toString(),
+          this.line as string,
+          ERROR_MESSAGES.SET_DCID,
+        ]);
         return;
       }
       ParseMcf.localNodeHash[ns + nodeRef] = this.curNode;
@@ -186,23 +201,36 @@ class ParseMcf {
    */
   setCurNodeDCID(parsedValues: (string | Object)[]) {
     if (!this.curNode) {
-      this.errors.push(
-          [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.SET_DCID_NO_CUR]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.SET_DCID_NO_CUR,
+      ]);
       return;
     }
     if (parsedValues.length !== 1) {
-      this.errors.push(
-          [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.SET_DCID_MULTIPLE]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.SET_DCID_MULTIPLE,
+      ]);
       return;
     }
     if (typeof parsedValues[0] !== 'string') {
-      this.errors.push(
-          [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.SET_DCID_REF]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.SET_DCID_REF,
+      ]);
       return;
     }
 
     if (!this.curNode.setDCID(parsedValues[0])) {
-      this.errors.push([this.lineNum.toString(), this.line as string, ERROR_MESSAGES.SET_DCID]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.SET_DCID,
+      ]);
     }
   }
 
@@ -216,21 +244,32 @@ class ParseMcf {
    * @param {Array<string|Object>} parsedValues The parsed values from a line of
    *     mcf, used to create the target for each created triple.
    */
-  createAssertionsFromParsedValues(propLabel: string, parsedValues: (string | Object)[]) {
+  createAssertionsFromParsedValues(
+      propLabel: string,
+      parsedValues: (string | Object)[],
+  ) {
     if (!this.curNode) {
-      this.errors.push(
-          [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.ASSERT_NO_CUR]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.ASSERT_NO_CUR,
+      ]);
       return;
     }
     for (const val of parsedValues) {
       let target;
       if (val instanceof Object) {
         const parsedVal = val as ParsedValue;
-        target = Node.getNode(NAMESPACES[parsedVal['ns']] + ':' + parsedVal['ref']);
+        target = Node.getNode(
+            NAMESPACES[parsedVal['ns']] + ':' + parsedVal['ref'],
+        );
         if (NAMESPACES[parsedVal['ns']] === 'dcid') {
           if (!target.setDCID(parsedVal['ref'])) {
-            this.errors.push(
-                [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.SET_DCID]);
+            this.errors.push([
+              this.lineNum.toString(),
+              this.line as string,
+              ERROR_MESSAGES.SET_DCID,
+            ]);
           }
         }
       } else {
@@ -257,8 +296,11 @@ class ParseMcf {
     }
 
     if (!line.includes(':')) {
-      this.errors.push(
-          [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.PARSE_NO_COLON]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.PARSE_NO_COLON,
+      ]);
       return;
     }
 
@@ -266,8 +308,11 @@ class ParseMcf {
     const propValues = line.substring(line.indexOf(':') + 1).trim();
 
     if (!propLabel) {
-      this.errors.push(
-          [this.lineNum.toString(), this.line as string, ERROR_MESSAGES.PARSE_NO_LABEL]);
+      this.errors.push([
+        this.lineNum.toString(),
+        this.line as string,
+        ERROR_MESSAGES.PARSE_NO_LABEL,
+      ]);
       return;
     }
     if (!propValues) {
@@ -325,7 +370,7 @@ class ParseMcf {
     fileReader.readAsText(file);
 
     return new Promise((res, rej) => {
-      fileReader.addEventListener('loadend', (result) => {
+      fileReader.addEventListener('loadend', () => {
         const mcfParser = new ParseMcf((file as File).name);
         res(mcfParser.parseMcfStr(fileReader.result as string));
       });

--- a/mcf-browser/src/back-end/parse-tmcf.ts
+++ b/mcf-browser/src/back-end/parse-tmcf.ts
@@ -52,7 +52,7 @@ class ParseTmcf {
    * Current row number of the csv file that is being parsed.
    * @type {number}
    */
-  csvIndex;
+  csvIndex: number;
 
   /**
   * Create a ParseTmcf object which keeps tracks of the current csv row
@@ -187,7 +187,7 @@ class ParseTmcf {
     const fileReader = new FileReader();
     fileReader.readAsText(csvFile);
     return new Promise((res, rej) => {
-      fileReader.addEventListener('loadend', (result) => {
+      fileReader.addEventListener('loadend', () => {
         const csv = require('csvtojson');
         csv()
             .fromString(fileReader.result)
@@ -204,12 +204,14 @@ class ParseTmcf {
    * @param {FileObject} tmcfFile The tmcf file from html file-input element.
    * @return {string} The string representation of the tmcf file.
    */
-  static async readTmcfFile(tmcfFile: Blob): Promise<string | ArrayBuffer | null> {
+  static async readTmcfFile(
+      tmcfFile: Blob,
+  ): Promise<string | ArrayBuffer | null> {
     const fileReader = new FileReader();
     fileReader.readAsText(tmcfFile);
     return new Promise((res, rej) => {
       fileReader.addEventListener('loadend',
-          (result) => {
+          () => {
             res(fileReader.result);
           });
       fileReader.addEventListener('error', rej);
@@ -223,10 +225,12 @@ class ParseTmcf {
    * @return {string} The translated mcf as a string.
    */
   static async generateMcf(tmcfFile: Blob, csvFile: Blob) {
-    return ParseTmcf.readTmcfFile(tmcfFile).then((template: string | ArrayBuffer | null) => {
-      const tmcfParser = new ParseTmcf();
-      return tmcfParser.readCsvFile(template as string, csvFile);
-    });
+    return ParseTmcf.readTmcfFile(tmcfFile).then(
+        (template: string | ArrayBuffer | null) => {
+          const tmcfParser = new ParseTmcf();
+          return tmcfParser.readCsvFile(template as string, csvFile);
+        },
+    );
   }
 }
 

--- a/mcf-browser/src/back-end/server-api.ts
+++ b/mcf-browser/src/back-end/server-api.ts
@@ -48,14 +48,14 @@ async function readFileList(fileList: Blob[]) {
     const fileName = (file as File).name;
     const fileExt = fileName.split('.').pop();
 
-    if (fileExt === "tmcf"){
+    if (fileExt === 'tmcf') {
       if (tmcfFile) {
         // If another TMCF file was found, throw an error
         finalReturn['errMsgs'] = finalReturn['errMsgs'].concat([{
           'file': (tmcfFile as File).name,
           'errs': [
-            ["-1", "", ERROR_MESSAGES.MULTIPLE_TMCF]
-          ]
+            ['-1', '', ERROR_MESSAGES.MULTIPLE_TMCF],
+          ],
         }]);
       }
 
@@ -76,7 +76,7 @@ async function readFileList(fileList: Blob[]) {
           'errs': mcfOut['errMsgs'],
         }]);
       }
-      
+
       finalReturn['localNodes'] = mcfOut['localNodes'];
     } else if (fileExt === 'csv') {
       if (tmcfFile) {
@@ -166,7 +166,10 @@ async function getElemClass(target: Node) {
       return 'exist-in-local';
     }
 
-    if (!target.dcid && !((target.localId as string) in ParseMcf.localNodeHash)) {
+    if (
+      !target.dcid &&
+      !((target.localId as string) in ParseMcf.localNodeHash)
+    ) {
       return 'not-in-local';
     }
     return 'not-in-kg';

--- a/mcf-browser/src/back-end/test/parse-mcf.test.ts
+++ b/mcf-browser/src/back-end/test/parse-mcf.test.ts
@@ -139,7 +139,7 @@ test('testing node values with createAssertionsFromParsedValues', () => {
     targetlocalId: string | null,
     targetDCID: string | null,
     property: string,
-    provenance: string 
+    provenance: string
   };
   const assertionToJSON = (assertion: Assertion) => {
     const {property, provenance} = assertion;
@@ -214,7 +214,7 @@ type AssertionJSON = {
   targetDCID?: string | null,
   target?: string | null,
   property: string,
-  provenance: string 
+  provenance: string
 };
 
 test('testing ParseMcfStr: ', () => {
@@ -230,12 +230,12 @@ test('testing ParseMcfStr: ', () => {
       return {
         ...json,
         targetlocalId: assertion.target.localId,
-        targetDCID: assertion.target.dcid
+        targetDCID: assertion.target.dcid,
       };
     } else {
       return {
         ...json,
-        target: assertion.target
+        target: assertion.target,
       };
     }
     return json;
@@ -269,7 +269,7 @@ test('testing ParseMcfStr: ', () => {
     const expectedJSONStart = {
       'srclocalId': obsNode.localId,
       'srcDCID': obsNode.dcid,
-      'provenance': fileName
+      'provenance': fileName,
     };
 
     const assertJSON = assertionToJSON(assert);
@@ -280,7 +280,7 @@ test('testing ParseMcfStr: ', () => {
           ...expectedJSONStart,
           property: 'remoteNodeProp',
           targetlocalId: null,
-          targetDCID: 'StatVarObservation'
+          targetDCID: 'StatVarObservation',
         };
 
         expect(assert.target.invAssertions[0]).toStrictEqual(assert);
@@ -292,7 +292,7 @@ test('testing ParseMcfStr: ', () => {
           ...expectedJSONStart,
           property: 'localNodeProp',
           targetlocalId: 'l:LocalIndiaNode',
-          targetDCID: 'country/IND'
+          targetDCID: 'country/IND',
         };
 
         expect(assert.target.invAssertions[0]).toStrictEqual(assert);
@@ -303,7 +303,7 @@ test('testing ParseMcfStr: ', () => {
         expectedJSON = {
           ...expectedJSONStart,
           property: 'stringProp',
-          target: '2020-08-01'
+          target: '2020-08-01',
         };
 
         expect(assertJSON).toStrictEqual(expectedJSON);
@@ -313,7 +313,7 @@ test('testing ParseMcfStr: ', () => {
         expectedJSON = {
           ...expectedJSONStart,
           property: 'numProp',
-          target: '10000'
+          target: '10000',
         };
 
         expect(assertJSON).toStrictEqual(expectedJSON);
@@ -322,7 +322,7 @@ test('testing ParseMcfStr: ', () => {
         expectedJSON = {
           ...expectedJSONStart,
           property: 'bioID',
-          target: 'GO:bioTextId'
+          target: 'GO:bioTextId',
         };
 
         expect(assertJSON).toStrictEqual(expectedJSON);
@@ -377,13 +377,13 @@ test('testing errors: ', () => {
   mcfParser.parseLine('val:'); // #9
 
   expect(mcfParser.errors).toEqual([
-    ["-1", null, ERROR_MESSAGES.CUR_NODE_LENGTH], // #1
-    ["-1", null, ERROR_MESSAGES.CUR_NODE_NS], // #2
-    ["-1", null, ERROR_MESSAGES.ASSERT_NO_CUR], // #3
-    ["-1", null, ERROR_MESSAGES.SET_DCID_MULTIPLE], // #4
-    ["-1", null, ERROR_MESSAGES.SET_DCID_REF], // #5
-    ["-1", null, ERROR_MESSAGES.SET_DCID], // #6
-    ["-1", null, ERROR_MESSAGES.PARSE_NO_COLON], // #7
-    ["-1", null, ERROR_MESSAGES.PARSE_NO_LABEL], // #8
+    ['-1', null, ERROR_MESSAGES.CUR_NODE_LENGTH], // #1
+    ['-1', null, ERROR_MESSAGES.CUR_NODE_NS], // #2
+    ['-1', null, ERROR_MESSAGES.ASSERT_NO_CUR], // #3
+    ['-1', null, ERROR_MESSAGES.SET_DCID_MULTIPLE], // #4
+    ['-1', null, ERROR_MESSAGES.SET_DCID_REF], // #5
+    ['-1', null, ERROR_MESSAGES.SET_DCID], // #6
+    ['-1', null, ERROR_MESSAGES.PARSE_NO_COLON], // #7
+    ['-1', null, ERROR_MESSAGES.PARSE_NO_LABEL], // #8
   ]);
 });

--- a/mcf-browser/src/back-end/utils.ts
+++ b/mcf-browser/src/back-end/utils.ts
@@ -33,7 +33,8 @@ const ERROR_MESSAGES =
       ASSERT_NO_CUR: 'current node must be set before declaring properties',
       PARSE_NO_COLON: 'missing \':\', incorrect mcf triple format',
       PARSE_NO_LABEL: 'missing property label',
-      MULTIPLE_TMCF: 'multiple TMCF files were uploaded, only the last one was used',
+      MULTIPLE_TMCF:
+          'multiple TMCF files were uploaded, only the last one was used',
     };
 
 /** A type to represent the format of the errors in the errList prop */

--- a/mcf-browser/src/utils.ts
+++ b/mcf-browser/src/utils.ts
@@ -24,7 +24,7 @@ const colorLegend = {
 
 /* Simple type to represent index of colorLegend */
 export type ColorIndex =
-  "exist-in-kg" | "exist-in-local" | "not-in-local" | "not-in-kg";
+  'exist-in-kg' | 'exist-in-local' | 'not-in-local' | 'not-in-kg';
 
 /**
  * Sets the window hash value to query a given id.


### PR DESCRIPTION
This PR contains formatting changes after switching the linter over to a typescript linter. Also removes duplicates of FileEntryStateType and FileEntryPropType.