### PR TITLE
Specify project and image version in cloudbuild.yaml

### DIFF
--- a/periodic_builds/cloudbuild.allrepos.yaml
+++ b/periodic_builds/cloudbuild.allrepos.yaml
@@ -14,7 +14,7 @@
 
 steps:
   - id: "build all repos"
-    name: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+    name: gcr.io/google.com/cloudsdktool/google-cloud-cli:397.0.0
     entrypoint: "bash"
     dir: "periodic_builds"
     args: ["./build_all_repos.sh"]

--- a/periodic_builds/cloudbuild.allrepos.yaml
+++ b/periodic_builds/cloudbuild.allrepos.yaml
@@ -30,6 +30,7 @@ options:
   - "TMP_FOLDER=/tmp"
   - "SUCCESS_FOLDER=/tmp/success"
   - "FAILED_FOLDER=/tmp/failed"
+  - "CLOUDSDK_CORE_PROJECT=datcom-ci"
   volumes:
   - name : "step_persistent_tmp"
     path: "/tmp"


### PR DESCRIPTION
- specify project in environment variables
- target a specific `google-cloud-cli` container image instead of `latest` to mitigate impact of breaking changes to the CLI