### PR TITLE
Remove manual scaling for BT automation

### DIFF
--- a/bigtable_automation/gcf/custom_instance.go
+++ b/bigtable_automation/gcf/custom_instance.go
@@ -85,6 +85,9 @@ func customInternal(ctx context.Context, e GCSEvent) error {
 			return err
 		}
 		log.Printf("[%s] State Launched", e.Name)
+	} else if strings.HasSuffix(e.Name, completedFile) {
+		// TODO: else, notify Mixer to load the BT table.
+		log.Printf("[%s] Completed work", e.Name)
 	}
 	return nil
 }

--- a/bigtable_automation/gcf/local/deploy.sh
+++ b/bigtable_automation/gcf/local/deploy.sh
@@ -27,7 +27,7 @@ if [[ "$1" == "flex" ]]; then
 fi
 
 # Good to read the yaml file keys and convert them to bash array
-for var in projectID cluster instance nodesHigh nodesLow dataflowTemplate dataPath controlPath
+for var in projectID cluster instance dataflowTemplate dataPath controlPath
 do
     value=$(yq eval .$var $config_file)
     export $var=$value

--- a/bigtable_automation/gcf/local/local.yaml
+++ b/bigtable_automation/gcf/local/local.yaml
@@ -1,8 +1,6 @@
 projectID: "google.com:datcom-store-dev"
 instance: "prophet-test"
 cluster: "prophet-test-c1"
-nodesHigh: "3"
-nodesLow: "1"
 dataflowTemplate: "gs://datcom-dataflow-templates/templates/csv_to_bt_improved"
 dataPath: "gs://prophet_cache"
 controlPath: "gs://automation_control_test/branch"

--- a/bigtable_automation/gcf/prod.go
+++ b/bigtable_automation/gcf/prod.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,8 +27,6 @@ func prodInternal(ctx context.Context, e GCSEvent) error {
 	projectID := os.Getenv("projectID")
 	instance := os.Getenv("instance")
 	cluster := os.Getenv("cluster")
-	nodesHigh := os.Getenv("nodesHigh")
-	nodesLow := os.Getenv("nodesLow")
 	dataflowTemplate := os.Getenv("dataflowTemplate")
 	dataPath := os.Getenv("dataPath")
 	controlPath := os.Getenv("controlPath")
@@ -50,15 +47,6 @@ func prodInternal(ctx context.Context, e GCSEvent) error {
 	}
 	if controlPath == "" {
 		return errors.New("controlPath is not set in environment")
-	}
-	// Get low and high nodes number
-	nodesH, err := strconv.Atoi(nodesHigh)
-	if err != nil {
-		return errors.Wrap(err, "Unable to parse 'nodesHigh' as an integer")
-	}
-	nodesL, err := strconv.Atoi(nodesLow)
-	if err != nil {
-		return errors.Wrap(err, "Unable to parse 'nodesLow' as an integer")
 	}
 	// Get control bucket and object
 	controlBucket, controlFolder, err := parsePath(controlPath)
@@ -83,11 +71,6 @@ func prodInternal(ctx context.Context, e GCSEvent) error {
 		return nil
 	}
 
-	numNodes, err := getBTNodes(ctx, projectID, instance, cluster)
-	if err != nil {
-		return err
-	}
-
 	if strings.HasSuffix(e.Name, initFile) {
 		log.Printf("[%s] State Init", e.Name)
 		// Called when the state-machine is at Init. Logic below moves it to Launched state.
@@ -99,36 +82,22 @@ func prodInternal(ctx context.Context, e GCSEvent) error {
 		if exist {
 			return errors.WithMessagef(err, "Cache was already built for %s", tableID)
 		}
-		if err := setupBT(ctx, projectID, instance, tableID); err != nil {
-			return err
-		}
-		if numNodes < nodesH {
-			if err := scaleBT(ctx, projectID, instance, cluster, int32(nodesH)); err != nil {
-				return err
-			}
-		}
 		err = launchDataflowJob(ctx, projectID, instance, tableID, dataPath, controlPath, dataflowTemplate)
 		if err != nil {
+			if errDeleteBT := deleteBTTable(ctx, projectID, instance, tableID); errDeleteBT != nil {
+				log.Printf("Failed to delete BT table on failed GCS write: %v", errDeleteBT)
+			}
 			return err
 		}
 		// Save the fact that we've launched the dataflow job.
 		err = writeToGCS(ctx, launchedPath, "")
 		if err != nil {
+			if errDeleteBT := deleteBTTable(ctx, projectID, instance, tableID); errDeleteBT != nil {
+				log.Printf("Failed to delete BT table on failed GCS write: %v", errDeleteBT)
+			}
 			return err
 		}
 		log.Printf("[%s] State Launched", e.Name)
-	} else if strings.HasSuffix(e.Name, completedFile) {
-		log.Printf("[%s] State Completed", e.Name)
-		// Called when the state-machine moves to Completed state from Launched.
-		if numNodes == nodesH {
-			// Only scale down BT nodes when the current high node is set up this config.
-			// This requires different high nodes in different config.
-			if err := scaleBT(ctx, projectID, instance, cluster, int32(nodesL)); err != nil {
-				return err
-			}
-		}
-		// TODO: else, notify Mixer to load the BT table.
-		log.Printf("[%s] Completed work", e.Name)
 	}
 	return nil
 }

--- a/bigtable_automation/gcf/prod.go
+++ b/bigtable_automation/gcf/prod.go
@@ -98,6 +98,9 @@ func prodInternal(ctx context.Context, e GCSEvent) error {
 			return err
 		}
 		log.Printf("[%s] State Launched", e.Name)
+	} else if strings.HasSuffix(e.Name, completedFile) {
+		// TODO: else, notify Mixer to load the BT table.
+		log.Printf("[%s] Completed work", e.Name)
 	}
 	return nil
 }

--- a/bigtable_automation/gcf/prod/base.yaml
+++ b/bigtable_automation/gcf/prod/base.yaml
@@ -1,8 +1,6 @@
 projectID: "datcom-store"
 instance: "prophet-cache"
 cluster: "prophet-cache-c1"
-nodesHigh: "298"
-nodesLow: "30"
 dataflowTemplate: "gs://datcom-templates/templates/csv_to_bt"
 dataPath: "gs://datcom-store"
 controlPath: "gs://datcom-control/base"

--- a/bigtable_automation/gcf/prod/branch.yaml
+++ b/bigtable_automation/gcf/prod/branch.yaml
@@ -1,8 +1,6 @@
 projectID: "datcom-store"
 instance: "prophet-branch-cache"
 cluster: "prophet-branch-cache-c1"
-nodesHigh: "3"
-nodesLow: "1"
 dataflowTemplate: "gs://datcom-templates/templates/csv_to_bt"
 dataPath: "gs://datcom-store"
 controlPath: "gs://datcom-control/branch"

--- a/bigtable_automation/terraform/main.tf
+++ b/bigtable_automation/terraform/main.tf
@@ -47,7 +47,7 @@ data "archive_file" "bt_automation_go_source" {
 # Upload zipped go source. Consumed by gcf.
 resource "google_storage_bucket_object" "bt_automation_archieve" {
     # Relative path in the resource bucket to upload the archieve.
-    name   = "cloud_functions/bt_automation_go_source.zip"
+    name   = "cloud_functions/bt_automation_go_source_${data.archive_file.bt_automation_go_source.output_base64sha256}.zip"
     source = "${path.module}/source/bt_automation_go_source.zip"
     bucket = var.dc_resource_bucket
 
@@ -58,7 +58,7 @@ resource "google_storage_bucket_object" "bt_automation_archieve" {
 
 resource "google_cloudfunctions_function" "bt_automation" {
   name        = format(
-      "prophet-cache-trigger-%s%s", var.project_id, local.resource_suffix)
+      "prophet-cache-trigger%s", local.resource_suffix)
   project        = var.project_id
   description = "For triggering BT cache build on gcs file writes."
   runtime     = "go116"


### PR DESCRIPTION
Use auto-scaling feature instead. 

- For custom DC, this completes the BT automation setup because Terraform configures autoscaling for BT.
- For main DC, this should prevent the problem of unintended scale down of BT during long running jobs from multiple import groups.

Using datcom-store-dev, I copied over a few [caches](https://pantheon.corp.google.com/storage/browser/automation_control_test/alex20221220/cache?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&mods=-monitoring_api_staging&project=google.com:datcom-store-dev&prefix=&forceOnObjectsSortingFiltering=false); 1 infrequent and a few frequents. Manually copied over a few init.txt files over to trigger concurrent Dataflow jobs. # of BT nodes scaled to the max(200) and [frequent finished](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2022-12-20_17_29_25-17789049836021027587;graphView=0?project=google.com:datcom-store-dev) in ~30min. [Infrequent is still running](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2022-12-20_17_05_38-14593584664668983817;graphView=0?project=google.com:datcom-store-dev). 

Also a few small improvements
- Add a hash as a part of the gcf source archive name to force an upload everyfile source changes.
- Delete BT tables when Dataflow fails to launch or GCS write fails.
 