### PR TITLE
[Custom DC] Add a csv file trigger for controller runner PubSub

### DIFF
--- a/bigtable_automation/gcf/common.go
+++ b/bigtable_automation/gcf/common.go
@@ -14,10 +14,10 @@
 
 // Package gcf runs a GCF function that triggers in 2 scenarios:
 //
-// 1) completion of prophet-flume job in borg. On triggering it sets up new
-//    cloud BT table, scales up BT cluster (if needed) and starts a dataflow job.
-// 2) completion of BT cache ingestion dataflow job. It scales BT cluster down
-//    (if needed).
+//  1. completion of prophet-flume job in borg. On triggering it sets up new
+//     cloud BT table, scales up BT cluster (if needed) and starts a dataflow job.
+//  2. completion of BT cache ingestion dataflow job. It scales BT cluster down
+//     (if needed).
 //
 // There are two set of trigger functions defined:
 // - ProdBTImportController
@@ -44,7 +44,6 @@ const (
 	createTableRetries = 3
 	columnFamily       = "csv"
 	gsScheme           = "gs://"
-	csvFileExtension   = ".csv"
 )
 
 // GCSEvent is the payload of a GCS event.

--- a/bigtable_automation/gcf/common.go
+++ b/bigtable_automation/gcf/common.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -42,6 +43,8 @@ import (
 const (
 	createTableRetries = 3
 	columnFamily       = "csv"
+	gsScheme           = "gs://"
+	csvFileExtension   = ".csv"
 )
 
 // GCSEvent is the payload of a GCS event.
@@ -127,4 +130,44 @@ func deleteBTTable(ctx context.Context, projectID, instance, table string) error
 		return errors.Wrap(err, "Unable to create a table admin client")
 	}
 	return adminClient.DeleteTable(ctx, table)
+}
+
+// ImportGCSPath holds GCS path info for custom dc v1.
+// import name inside the pubsub message to trigger controller must match
+// the import name in config.textproto (specified by customManifestPath).
+// Ideally we should read import name from config.text proto directly, but
+// since manifest protos are not public yet, we will use the folder name instead.
+//
+// Custom DC resource bucket MUST follow the following directory structure.
+// <resource bucket name>/<some path>/<import name>/config/config.textproto
+// <resource bucket name>/<some path>/<import name>/tmcf_csv/*.csv
+// <resource bucket name>/<some path>/<import name>/tmcf_csv/*.tmcf
+// <resource bucket name>/<some path>/<import name>/<other folders like control, cache>
+type ImportGCSPath struct {
+	// GCS base path for a particular import.
+	// This should be under the resource bucket.
+	importName string
+}
+
+func (p ImportGCSPath) ImportName() string {
+	return filepath.Base(p.importName)
+}
+
+// ConfigPath must be <base>/config/config.textproto
+func (p ImportGCSPath) ConfigPath() string {
+	return filepath.Join(p.importName, "config", "config.textproto")
+}
+
+// DataDirectory is the expected location for tmcf and csvs.
+// It is expected that csv files are dropped off in this directory.
+func (p ImportGCSPath) DataDirectory() string {
+	return filepath.Join(p.importName, "tmcf_csv")
+}
+
+func (p ImportGCSPath) CacheDirectory() string {
+	return filepath.Join(p.importName, "cache")
+}
+
+func (p ImportGCSPath) ControlDirectory() string {
+	return filepath.Join(p.importName, "control")
 }

--- a/bigtable_automation/gcf/controller_trigger.go
+++ b/bigtable_automation/gcf/controller_trigger.go
@@ -91,9 +91,10 @@ func (s CustomDCPubSubMsg) Publish(ctx context.Context, p PublishConfig) error {
 }
 
 // triggerPath is .../<import_name>/process/<import id>/trigger.txt
+// process folder is currently only used for control purposes for 1 process: trigger controller.
 func TriggerController(ctx context.Context, p PublishConfig, triggerPath string) error {
-	imoprtName := filepath.Dir(filepath.Dir(filepath.Dir(triggerPath)))
-	path := ImportGCSPath{importName: imoprtName}
+	importName := filepath.Dir(filepath.Dir(filepath.Dir(triggerPath)))
+	path := ImportGCSPath{importName: importName}
 
 	msg := CustomDCPubSubMsg{
 		importName:               path.ImportName(),

--- a/bigtable_automation/gcf/controller_trigger.go
+++ b/bigtable_automation/gcf/controller_trigger.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,47 +25,48 @@ import (
 )
 
 const (
-	dcManifestPath = "/memfile/core_resolved_mcfs_memfile/core_resolved_mcfs.binarypb"
+	dcManifestPath        = "/memfile/core_resolved_mcfs_memfile/core_resolved_mcfs.binarypb"
+	controllerTriggerFile = "trigger.txt"
 )
 
 type PublishConfig struct {
 	// TopicName is the full PubSub topic name in the following format
 	// projects/<project id>/topics/<topic id>
-	FullTopicName string
+	TopicName string
 }
 
 func (p PublishConfig) ProjectID() string {
-	return strings.Split(p.FullTopicName, "/")[1]
+	return strings.Split(p.TopicName, "/")[1]
 }
 
-func (p PublishConfig) TopicName() string {
-	return strings.Split(p.FullTopicName, "/")[3]
+func (p PublishConfig) TopicID() string {
+	return strings.Split(p.TopicName, "/")[3]
 }
 
 type CustomDCPubSubMsg struct {
-	importName string
-	dcManifestPath string
-	customManifestPath string
-	bigstoreDataDirectory string
-	bigstoreCacheDirectory string
+	importName               string
+	dcManifestPath           string
+	customManifestPath       string
+	bigstoreDataDirectory    string
+	bigstoreCacheDirectory   string
 	bigstoreControlDirectory string
 }
 
 func (s CustomDCPubSubMsg) String() string {
-		return fmt.Sprintf(`import_name=%s,\
+	return fmt.Sprintf(`import_name=%s,\
 dc_manifest_path=%s,\
 custom_manifest_path=%s,\
 bigstore_data_directory=%s,\
 bigstore_cache_directory=%s,\
 bigstore_control_directory=%s,\
 `,
-				s.importName,
-				s.dcManifestPath,
-				s.customManifestPath,
-				s.bigstoreDataDirectory,
-				s.bigstoreCacheDirectory,
-				s.bigstoreControlDirectory,
-		)
+		s.importName,
+		s.dcManifestPath,
+		s.customManifestPath,
+		s.bigstoreDataDirectory,
+		s.bigstoreCacheDirectory,
+		s.bigstoreControlDirectory,
+	)
 }
 
 // Publish publishes the current import config to a topic.
@@ -76,7 +77,7 @@ func (s CustomDCPubSubMsg) Publish(ctx context.Context, p PublishConfig) error {
 	}
 	defer client.Close()
 
-	t := client.Topic(p.TopicName())
+	t := client.Topic(p.TopicID())
 	res := t.Publish(ctx, &pubsub.Message{
 		Data: []byte(s.String()),
 	})
@@ -98,11 +99,11 @@ func TriggerController(ctx context.Context, p PublishConfig, csvPath string) err
 	path := ImportGCSPath{importName: filepath.Dir(tmcfCSVDir)}
 
 	msg := CustomDCPubSubMsg{
-		importName: path.ImportName(),
-		dcManifestPath: dcManifestPath,
-		customManifestPath: path.ConfigPath(),
-		bigstoreDataDirectory: path.DataDirectory(),
-		bigstoreCacheDirectory: path.CacheDirectory(),
+		importName:               path.ImportName(),
+		dcManifestPath:           dcManifestPath,
+		customManifestPath:       path.ConfigPath(),
+		bigstoreDataDirectory:    path.DataDirectory(),
+		bigstoreCacheDirectory:   path.CacheDirectory(),
 		bigstoreControlDirectory: path.ControlDirectory(),
 	}
 	return msg.Publish(ctx, p)

--- a/bigtable_automation/gcf/controller_trigger.go
+++ b/bigtable_automation/gcf/controller_trigger.go
@@ -90,13 +90,10 @@ func (s CustomDCPubSubMsg) Publish(ctx context.Context, p PublishConfig) error {
 	return nil
 }
 
-func TriggerController(ctx context.Context, p PublishConfig, csvPath string) error {
-	tmcfCSVDir := filepath.Dir(csvPath)
-	if tmcfCSVFolderName := filepath.Base(tmcfCSVDir); tmcfCSVFolderName != "tmcf_csv" {
-		return fmt.Errorf("csv file is not under %s", "tmcf_csv")
-	}
-
-	path := ImportGCSPath{importName: filepath.Dir(tmcfCSVDir)}
+// triggerPath is .../<import_name>/process/<import id>/trigger.txt
+func TriggerController(ctx context.Context, p PublishConfig, triggerPath string) error {
+	imoprtName := filepath.Dir(filepath.Dir(filepath.Dir(triggerPath)))
+	path := ImportGCSPath{importName: imoprtName}
 
 	msg := CustomDCPubSubMsg{
 		importName:               path.ImportName(),

--- a/bigtable_automation/gcf/controller_trigger.go
+++ b/bigtable_automation/gcf/controller_trigger.go
@@ -1,0 +1,109 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gcf
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/pkg/errors"
+)
+
+const (
+	dcManifestPath = "/memfile/core_resolved_mcfs_memfile/core_resolved_mcfs.binarypb"
+)
+
+type PublishConfig struct {
+	// TopicName is the full PubSub topic name in the following format
+	// projects/<project id>/topics/<topic id>
+	FullTopicName string
+}
+
+func (p PublishConfig) ProjectID() string {
+	return strings.Split(p.FullTopicName, "/")[1]
+}
+
+func (p PublishConfig) TopicName() string {
+	return strings.Split(p.FullTopicName, "/")[3]
+}
+
+type CustomDCPubSubMsg struct {
+	importName string
+	dcManifestPath string
+	customManifestPath string
+	bigstoreDataDirectory string
+	bigstoreCacheDirectory string
+	bigstoreControlDirectory string
+}
+
+func (s CustomDCPubSubMsg) String() string {
+		return fmt.Sprintf(`import_name=%s,\
+dc_manifest_path=%s,\
+custom_manifest_path=%s,\
+bigstore_data_directory=%s,\
+bigstore_cache_directory=%s,\
+bigstore_control_directory=%s,\
+`,
+				s.importName,
+				s.dcManifestPath,
+				s.customManifestPath,
+				s.bigstoreDataDirectory,
+				s.bigstoreCacheDirectory,
+				s.bigstoreControlDirectory,
+		)
+}
+
+// Publish publishes the current import config to a topic.
+func (s CustomDCPubSubMsg) Publish(ctx context.Context, p PublishConfig) error {
+	client, err := pubsub.NewClient(ctx, p.ProjectID())
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	t := client.Topic(p.TopicName())
+	res := t.Publish(ctx, &pubsub.Message{
+		Data: []byte(s.String()),
+	})
+
+	id, err := res.Get(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to verify import notification msg was published")
+	}
+	log.Printf("PubSub import notification published with server generated msg id: %v\n", id)
+	return nil
+}
+
+func TriggerController(ctx context.Context, p PublishConfig, csvPath string) error {
+	tmcfCSVDir := filepath.Dir(csvPath)
+	if tmcfCSVFolderName := filepath.Base(tmcfCSVDir); tmcfCSVFolderName != "tmcf_csv" {
+		return fmt.Errorf("csv file is not under %s", "tmcf_csv")
+	}
+
+	path := ImportGCSPath{importName: filepath.Dir(tmcfCSVDir)}
+
+	msg := CustomDCPubSubMsg{
+		importName: path.ImportName(),
+		dcManifestPath: dcManifestPath,
+		customManifestPath: path.ConfigPath(),
+		bigstoreDataDirectory: path.DataDirectory(),
+		bigstoreCacheDirectory: path.CacheDirectory(),
+		bigstoreControlDirectory: path.ControlDirectory(),
+	}
+	return msg.Publish(ctx, p)
+}

--- a/bigtable_automation/gcf/go.mod
+++ b/bigtable_automation/gcf/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	cloud.google.com/go/bigtable v1.13.0
+	cloud.google.com/go/pubsub v1.28.0
 	cloud.google.com/go/storage v1.27.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.6.1
 	github.com/pkg/errors v0.9.1

--- a/bigtable_automation/gcf/go.sum
+++ b/bigtable_automation/gcf/go.sum
@@ -278,6 +278,8 @@ cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIA
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
 cloud.google.com/go/pubsub v1.26.0/go.mod h1:QgBH3U/jdJy/ftjPhTkyXNj543Tin1pRYcdcPRnFIRI=
 cloud.google.com/go/pubsub v1.27.1/go.mod h1:hQN39ymbV9geqBnfQq6Xf63yNhUAhv9CZhzp5O6qsW0=
+cloud.google.com/go/pubsub v1.28.0 h1:XzabfdPx/+eNrsVVGLFgeUnQQKPGkMb8klRCeYK52is=
+cloud.google.com/go/pubsub v1.28.0/go.mod h1:vuXFpwaVoIPQMGXqRyUQigu/AX1S3IWugR9xznmcXX8=
 cloud.google.com/go/pubsublite v1.5.0/go.mod h1:xapqNQ1CuLfGi23Yda/9l4bBCKz/wC3KIJ5gKcxveZg=
 cloud.google.com/go/recaptchaenterprise v1.3.1/go.mod h1:OdD+q+y4XGeAlxRaMn1Y7/GveP6zmq76byL6tjPE7d4=
 cloud.google.com/go/recaptchaenterprise/v2 v2.1.0/go.mod h1:w9yVqajwroDNTfGuhmOjPDN//rZGySaf6PtFVcSCa7o=
@@ -725,6 +727,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1044,6 +1047,7 @@ google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c/go.mod h1:CGI5F/G+
 google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
+google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd/go.mod h1:cTsE614GARnxrLsqKREzmNYJACSWWpAWdNMwnD7c2BE=
 google.golang.org/genproto v0.0.0-20221206210731-b1a01be3a5f6 h1:AGXp12e/9rItf6/4QymU7WsAUwCf+ICW75cuR91nJIc=
 google.golang.org/genproto v0.0.0-20221206210731-b1a01be3a5f6/go.mod h1:1dOng4TWOomJrDGhpXjfCD35wQC6jnC7HpRmOFRqEV0=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/bigtable_automation/terraform/main.tf
+++ b/bigtable_automation/terraform/main.tf
@@ -93,6 +93,10 @@ resource "google_cloudfunctions_function" "bt_automation" {
 
     dataflowTemplate = var.csv2bt_template_path
     tempLocation     = format("gs://%s/dataflow/tmp", var.dc_resource_bucket)
+
+    bucket           = var.dc_resource_bucket
+    controllerTriggerTopic = "projects/datcom-204919/topics/private-import-notification-prod"
+
   }
 
   depends_on = [


### PR DESCRIPTION
- Currently custom_instance.go only detects control state files -> also detect csv files.
- Manifest proto is currently not externalized, so we can't parse config.textproto easily.
  - As a workaround, assume top level import folder name is the same as import name
- Any csv file dropped in the resource bucket will send a PubSub trigger to controller runner. 
