### PR TITLE
Set a global import group instance id in pubsub message

### DIFF
--- a/gcf/custom.go
+++ b/gcf/custom.go
@@ -136,7 +136,11 @@ func customInternal(ctx context.Context, e lib.GCSEvent) error {
 		bigstoreControlDirectory := fmt.Sprintf("/bigstore/%s/%s/internal/control", bucket, importRootDir)
 
 		firstImport := manifest.Import[0]
+		// ID used to globally identify an import group under a project.
+		instanceID := fmt.Sprintf("%s_%s", projectID, *manifest.ImportGroups[0].Name)
+
 		attributes := map[string]string{
+			"instance_id":                instanceID,
 			"import_name":                *(firstImport.ImportName),
 			"dc_manifest_path":           dcManifestPath,
 			"custom_manifest_path":       bigstoreConfigPath,

--- a/gcf/custom/controller_trigger.go
+++ b/gcf/custom/controller_trigger.go
@@ -36,7 +36,11 @@ func getTopicInfo(topicName string) (
 }
 
 // Publish publishes the current import config to a topic.
-func Publish(ctx context.Context, topicName string, attributes map[string]string) error {
+func Publish(
+	ctx context.Context,
+	topicName string,
+	attributes map[string]string,
+) error {
 	log.Printf("Publishing to topic: %s, for the following attributes\n: %s", topicName, attributes)
 	projectID, topicID, err := getTopicInfo(topicName)
 	if err != nil {

--- a/gcf/custom/manifest.go
+++ b/gcf/custom/manifest.go
@@ -28,11 +28,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func importFilesToManifest(importGroupFiles *lib.ImportGroupFiles, bucket string) (*pb.DataCommonsManifest, error) {
-
-	var datasetImports []*pb.DataCommonsManifest_Import
-
+func importFilesToManifest(
+	importGroupFiles *lib.ImportGroupFiles,
+	bucket string,
+) (*pb.DataCommonsManifest, error) {
+	datasetImports := []*pb.DataCommonsManifest_Import{}
 	datasetSources := []*pb.DataCommonsManifest_DatasetSource{}
+
 	for dataSource, datasetNames := range importGroupFiles.Source2Datasets {
 		ds := &pb.DataCommonsManifest_DatasetSource{
 			Url:  proto.String("https://datacommons.org/"),
@@ -91,7 +93,10 @@ func importFilesToManifest(importGroupFiles *lib.ImportGroupFiles, bucket string
 // pathToDataFolder is the "gs://"-prefixed folder that contains raw data.
 // For the folder structure that is expected, please see,
 // https://docs.datacommons.org/custom_dc/upload_data.html
-func GenerateManifest(ctx context.Context, bucket, importRootDir string) (*pb.DataCommonsManifest, error) {
+func GenerateManifest(
+	ctx context.Context,
+	bucket, importRootDir string,
+) (*pb.DataCommonsManifest, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This will be used by controller runner as the instance_id and will deprecate "import_name" field.

Also made some minor formatting change for long line arguments