### PR TITLE
[Custom DC] Handle shemaless cases and when folders do not show up

### DIFF
--- a/gcf/custom/layout_test.go
+++ b/gcf/custom/layout_test.go
@@ -75,6 +75,29 @@ func TestLayout(t *testing.T) {
 			"",
 		},
 		{
+			"No folders",
+			"imports/root",
+			[]string{
+				"imports/root/data/california_distribution_grid/dataset1/california_distribution_lines.tmcf",
+				"imports/root/data/california_distribution_grid/dataset1/california_distribution_lines.csv",
+			},
+			&Layout{
+				root: "imports/root",
+				imports: map[string]*Import{
+					"california_distribution_grid": {
+						tables: map[string]*Table{
+							"empty": nil,
+							"dataset1": {
+								tmcf: "california_distribution_lines.tmcf",
+								csv:  []string{"california_distribution_lines.csv"},
+							},
+						},
+					},
+				},
+			},
+			"",
+		},
+		{
 			"Multiple tmcf should fail",
 			"demo",
 			[]string{

--- a/gcf/custom/manifest_test.go
+++ b/gcf/custom/manifest_test.go
@@ -64,6 +64,28 @@ func TestComputeManifest(t *testing.T) {
 			},
 			"golden.textproto",
 		},
+		{
+			"test-bucket",
+			&Layout{
+				root: "schemaless",
+				imports: map[string]*Import{
+					"import1": {
+						tables: map[string]*Table{
+							"empty": nil,
+							"smokepm": {
+								tmcf: "data.tmcf",
+								csv:  []string{"1.csv", "2.csv"},
+							},
+							"ocean": {
+								tmcf: "sea.tmcf",
+								csv:  []string{"river.csv", "lake.csv"},
+							},
+						},
+					},
+				},
+			},
+			"schemaless.textproto",
+		},
 	} {
 		_, filename, _, _ := runtime.Caller(0)
 		testDataDir := path.Join(path.Dir(filename), "test_data")

--- a/gcf/custom/test_data/schemaless.textproto
+++ b/gcf/custom/test_data/schemaless.textproto
@@ -1,0 +1,36 @@
+import: {
+  import_name: "import1"
+  provenance_url: "https://datacommons.org"
+  category: STATS
+  import_groups: "schemaless"
+  mcf_proto_url: "/bigstore/test-bucket/schemaless/data/import1/ocean/graph.tfrecord@*.gz"
+  mcf_proto_url: "/bigstore/test-bucket/schemaless/data/import1/smokepm/graph.tfrecord@*.gz"
+  table: {
+    mapping_path: "/bigstore/test-bucket/schemaless/data/import1/ocean/sea.tmcf"
+    csv_path: "/bigstore/test-bucket/schemaless/data/import1/ocean/river.csv"
+    csv_path: "/bigstore/test-bucket/schemaless/data/import1/ocean/lake.csv"
+  }
+  table: {
+    mapping_path: "/bigstore/test-bucket/schemaless/data/import1/smokepm/data.tmcf"
+    csv_path: "/bigstore/test-bucket/schemaless/data/import1/smokepm/1.csv"
+    csv_path: "/bigstore/test-bucket/schemaless/data/import1/smokepm/2.csv"
+  }
+  resolution_info: {
+    uses_id_resolver: true
+  }
+  automated_mcf_generation_by: "schemaless"
+  dataset_name: "import1"
+}
+import_groups: {
+  name: "schemaless"
+  description: "Custom DC import group"
+  is_custom_dc: true
+}
+dataset_source: {
+  name: "import1"
+  url: "https://datacommons.org"
+  datasets: {
+    name: "import1"
+    url: "https://datacommons.org"
+  }
+}


### PR DESCRIPTION
Context: Deployed latest GCF to Stanford instance to import Zhecheng's data, but got an error. It happens when folders do not show up as "/", which seems unpredictable. 

```
github.com/datacommonsorg/tools/gcf/custom.BuildLayout(0xc000040270, 0x10, 0xc00009b540, 0x2, 0x2, 0xc000040270, 0x10, 0xc00009b540)
	/workspace/serverless_function_source_code/custom/layout.go:109 +0x85f
```
Zhecheng's import is also schemaless, making schema Import optional.

TESTED=trigger.txt to zhecheng's folder.