### PR TITLE
remove automated_mcf_generation_by

### DIFF
--- a/gcf/custom/manifest.go
+++ b/gcf/custom/manifest.go
@@ -144,9 +144,6 @@ func ComputeManifest(
 			}
 
 			if len(tableFolder.tmcf) > 0 && len(tableFolder.csv) > 0 {
-				// Only set automated_mcf_generation_by for tmcf/csv imports.
-				// Setting this flag for mcf based imports will error out.
-				manifestImport.AutomatedMcfGenerationBy = proto.String(importGroup)
 				manifestImport.Table = append(
 					manifestImport.Table,
 					computeTable(bucket, root, im, tab, tableFolder),

--- a/gcf/custom/test_data/golden.textproto
+++ b/gcf/custom/test_data/golden.textproto
@@ -18,7 +18,6 @@ import: {
   resolution_info: {
     uses_id_resolver: true
   }
-  automated_mcf_generation_by: "demo"
   dataset_name: "import1"
 }
 import: {
@@ -34,7 +33,6 @@ import: {
   resolution_info: {
     uses_id_resolver: true
   }
-  automated_mcf_generation_by: "demo"
   dataset_name: "import2"
 }
 import: {

--- a/gcf/custom/test_data/schemaless.textproto
+++ b/gcf/custom/test_data/schemaless.textproto
@@ -18,7 +18,6 @@ import: {
   resolution_info: {
     uses_id_resolver: true
   }
-  automated_mcf_generation_by: "schemaless"
   dataset_name: "import1"
 }
 import_groups: {


### PR DESCRIPTION
As per @Spaceenter 's comment, this is not needed because we do not have auto refresh for custom DC instances atm.