### PR TITLE
Only run screenshot and sanity check for daily cron job

### DIFF
--- a/periodic_builds/builds.txt
+++ b/periodic_builds/builds.txt
@@ -5,5 +5,6 @@ mixer/build/ci/cloudbuild.test.yaml
 website/build/ci/cloudbuild.npm.yaml
 website/build/ci/cloudbuild.py.yaml
 website/build/ci/cloudbuild.webdriver.yaml
-website/build/ci/cloudbuild.website_testing.yaml _DOMAIN=dev.datacommons.org,_TEST=all
+website/build/ci/cloudbuild.website_testing.yaml _DOMAIN=dev.datacommons.org,_TEST=screenshot
+website/build/ci/cloudbuild.website_testing.yaml _DOMAIN=dev.datacommons.org,_TEST=sanity
 api-python/cloudbuild.yaml


### PR DESCRIPTION
Adversarial tests now runs for 1.5 hours. Turn that off before we can make it faster.