### PR TITLE
change sdk to 2.43.0 with BigtableOptions and set maxNumWorkers to 1000

### DIFF
--- a/bigtable_automation/java/dataflow/csv2bt-template-metadata.json
+++ b/bigtable_automation/java/dataflow/csv2bt-template-metadata.json
@@ -40,6 +40,13 @@
             "isOptional": true
         },
         {
+            "name": "bigtableMaxNumWorkers",
+            "label": "Bigtable maximum number of workers",
+            "helpText": "The maximum number of workers for Dataflow jobs.",
+            "paramType": "TEXT",
+            "isOptional": true
+        },
+        {
             "name": "tempLocation",
             "label": "GCP temp location",
             "helpText": "A GCS bucket where the running jobs will have access to.",

--- a/bigtable_automation/java/dataflow/csv2bt-template-metadata.json
+++ b/bigtable_automation/java/dataflow/csv2bt-template-metadata.json
@@ -40,8 +40,8 @@
             "isOptional": true
         },
         {
-            "name": "bigtableMaxNumWorkers",
-            "label": "Bigtable maximum number of workers",
+            "name": "dataflowMaxNumWorkers",
+            "label": "Dataflow maximum number of workers",
             "helpText": "The maximum number of workers for Dataflow jobs.",
             "paramType": "TEXT",
             "isOptional": true

--- a/bigtable_automation/java/dataflow/pom.xml
+++ b/bigtable_automation/java/dataflow/pom.xml
@@ -7,11 +7,11 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.53.0</beam.version>
+    <beam.version>2.43.0</beam.version>
     <bigtable.version>1.4.0</bigtable.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
   </properties>
 

--- a/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CloudBigtableOptions.java
+++ b/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CloudBigtableOptions.java
@@ -30,8 +30,8 @@ public interface CloudBigtableOptions extends DataflowPipelineOptions {
   void setBigtableAppProfileId(ValueProvider<String> bigtableAppProfileId);
 
   @Description("The maximum number of workers for Dataflow jobs.")
-  ValueProvider<String> getBigtableMaxNumWorkers();
+  ValueProvider<String> getDataflowMaxNumWorkers();
 
   @SuppressWarnings("unused")
-  void setBigtableMaxNumWorkers(ValueProvider<String> bigtableMaxNumWorkers);
+  void setDataflowMaxNumWorkers(ValueProvider<String> dataflowMaxNumWorkers);
 }

--- a/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CloudBigtableOptions.java
+++ b/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CloudBigtableOptions.java
@@ -28,4 +28,10 @@ public interface CloudBigtableOptions extends DataflowPipelineOptions {
 
   @SuppressWarnings("unused")
   void setBigtableAppProfileId(ValueProvider<String> bigtableAppProfileId);
+
+  @Description("The maximum number of workers for Dataflow jobs.")
+  ValueProvider<String> getBigtableMaxNumWorkers();
+
+  @SuppressWarnings("unused")
+  void setBigtableMaxNumWorkers(ValueProvider<String> bigtableMaxNumWorkers);
 }

--- a/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CsvImport.java
+++ b/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CsvImport.java
@@ -2,6 +2,7 @@ package org.datacommons.dataflow;
 
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Mutation.SetCell;
+import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
@@ -117,7 +118,10 @@ public class CsvImport {
   public static void main(String[] args) throws IllegalArgumentException {
     BigtableCsvOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(BigtableCsvOptions.class);
-
+    if (options.getBigtableMaxNumWorkers().isAccessible() && 
+        StringUtils.isNotEmpty(options.getBigtableMaxNumWorkers().get())) {
+      options.setMaxNumWorkers(Integer.parseInt(options.getBigtableMaxNumWorkers().get()));
+    }
     Pipeline pipeline = Pipeline.create(options);
     PCollection<KV<ByteString, Iterable<Mutation>>> cacheData = pipeline
         .apply("ReadMyFile", TextIO.read().from(options.getInputFile()).withHintMatchesManyFiles())
@@ -129,7 +133,10 @@ public class CsvImport {
         .withTableId(options.getBigtableTableId());
     if (options.getBigtableAppProfileId().isAccessible() &&
         StringUtils.isNotEmpty(options.getBigtableAppProfileId().get())) {
-      write = write.withAppProfileId(options.getBigtableAppProfileId());
+       BigtableOptions bigtableOptions = BigtableOptions.builder()
+        .setAppProfileId(options.getBigtableAppProfileId().get())
+        .build();
+      write = write.withBigtableOptions(bigtableOptions);
     }
     // Write with results.
     PCollection<BigtableWriteResult> writeResults = cacheData

--- a/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CsvImport.java
+++ b/bigtable_automation/java/dataflow/src/main/java/org/datacommons/dataflow/CsvImport.java
@@ -118,9 +118,9 @@ public class CsvImport {
   public static void main(String[] args) throws IllegalArgumentException {
     BigtableCsvOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(BigtableCsvOptions.class);
-    if (options.getBigtableMaxNumWorkers().isAccessible() && 
-        StringUtils.isNotEmpty(options.getBigtableMaxNumWorkers().get())) {
-      options.setMaxNumWorkers(Integer.parseInt(options.getBigtableMaxNumWorkers().get()));
+    if (options.getDataflowMaxNumWorkers().isAccessible() && 
+        StringUtils.isNotEmpty(options.getDataflowMaxNumWorkers().get())) {
+      options.setMaxNumWorkers(Integer.parseInt(options.getDataflowMaxNumWorkers().get()));
     }
     Pipeline pipeline = Pipeline.create(options);
     PCollection<KV<ByteString, Iterable<Mutation>>> cacheData = pipeline

--- a/gcf/base.go
+++ b/gcf/base.go
@@ -32,6 +32,7 @@ func prodInternal(ctx context.Context, e lib.GCSEvent) error {
 	dataPath := os.Getenv("dataPath")
 	controlPath := os.Getenv("controlPath")
 	appProfileID := os.Getenv("appProfileID")
+	maxNumWorkers := os.Getenv("maxNumWorkers")
 	if projectID == "" {
 		return errors.New("projectID is not set in environment")
 	}
@@ -87,7 +88,7 @@ func prodInternal(ctx context.Context, e lib.GCSEvent) error {
 		if err := lib.SetupBT(ctx, projectID, instance, tableID); err != nil {
 			return err
 		}
-		err = lib.LaunchDataflowJob(ctx, projectID, instance, tableID, dataPath, controlPath, dataflowTemplate, appProfileID)
+		err = lib.LaunchDataflowJob(ctx, projectID, instance, tableID, dataPath, controlPath, dataflowTemplate, appProfileID, maxNumWorkers)
 		if err != nil {
 			if errDeleteBT := lib.DeleteBTTable(ctx, projectID, instance, tableID); errDeleteBT != nil {
 				log.Printf("Failed to delete BT table on failed GCS write: %v", errDeleteBT)

--- a/gcf/base/gcp/config/base.yaml
+++ b/gcf/base/gcp/config/base.yaml
@@ -6,3 +6,4 @@ tempLocation: "gs://datcom-store-resources/dataflow/tmp"
 dataPath: "gs://datcom-store"
 controlPath: "gs://datcom-control/base"
 appProfileID: "batch"
+maxNumWorkers: 1000

--- a/gcf/base/gcp/config/branch.yaml
+++ b/gcf/base/gcp/config/branch.yaml
@@ -6,3 +6,4 @@ tempLocation: "gs://datcom-store-resources/dataflow/tmp"
 dataPath: "gs://datcom-store"
 controlPath: "gs://datcom-control/branch"
 appProfileID: "batch"
+maxNumWorkers: 1000

--- a/gcf/base/local/deploy.sh
+++ b/gcf/base/local/deploy.sh
@@ -27,7 +27,7 @@ if [[ "$1" == "flex" ]]; then
 fi
 
 # Good to read the yaml file keys and convert them to bash array
-for var in projectID cluster instance dataflowTemplate dataPath controlPath appProfileID
+for var in projectID cluster instance dataflowTemplate dataPath controlPath appProfileID maxNumWorkers
 do
     value=$(yq eval .$var $config_file)
     export $var=$value

--- a/gcf/base/local/local_flex.yaml
+++ b/gcf/base/local/local_flex.yaml
@@ -8,3 +8,4 @@ dataPath: "gs://prophet_cache"
 controlPath: "gs://automation_control_test/branch"
 tempLocation: "gs://datcom-store-dev-resources/dataflow/tmp"
 appProfileID: "batch"
+maxNumWorkers: 1000

--- a/gcf/custom.go
+++ b/gcf/custom.go
@@ -36,6 +36,7 @@ func customInternal(ctx context.Context, e lib.GCSEvent) error {
 	instance := os.Getenv("instance")
 	cluster := os.Getenv("cluster")
 	dataflowTemplate := os.Getenv("dataflowTemplate")
+	maxNumWorkers := os.Getenv("maxNumWorkers")
 	if projectID == "" {
 		return errors.New("projectID is not set in environment")
 	}
@@ -78,7 +79,7 @@ func customInternal(ctx context.Context, e lib.GCSEvent) error {
 		}
 		dataPath := lib.JoinURL(rootFolder, "cache")
 		controlPath := lib.JoinURL(rootFolder, "control")
-		err = lib.LaunchDataflowJob(ctx, projectID, instance, tableID, dataPath, controlPath, dataflowTemplate, "")
+		err = lib.LaunchDataflowJob(ctx, projectID, instance, tableID, dataPath, controlPath, dataflowTemplate, "", maxNumWorkers)
 		if err != nil {
 			if errDeleteBT := lib.DeleteBTTable(ctx, projectID, instance, tableID); errDeleteBT != nil {
 				log.Printf("Failed to delete BT table on failed Dataflow launch: %v", errDeleteBT)

--- a/gcf/lib/dataflow_launcher.go
+++ b/gcf/lib/dataflow_launcher.go
@@ -125,7 +125,7 @@ func launchFromFlexTemplate(
 			"bigtableProjectId":     projectID,
 			"tempLocation":          tempLocation,
 			"bigtableAppProfileId":  appProfileID,
-			"bigtableMaxNumWorkers": maxNumWorkers,
+			"dataflowMaxNumWorkers": maxNumWorkers,
 		},
 		ContainerSpecGcsPath: dataflowTemplate,
 	}
@@ -176,7 +176,7 @@ func launchFromClassicTemplate(
 			"bigtableProjectId":     projectID,
 			"region":                region,
 			"bigtableAppProfileId":  appProfileID,
-			"bigtableMaxNumWorkers": maxNumWorkers,
+			"dataflowMaxNumWorkers": maxNumWorkers,
 		},
 	}
 	log.Printf("[%s/%s] Launching dataflow job: %s -> %s\n", instance, tableID, dataFile, launchedPath)

--- a/gcf/lib/dataflow_launcher.go
+++ b/gcf/lib/dataflow_launcher.go
@@ -58,6 +58,7 @@ func LaunchDataflowJob(
 	controlPath string,
 	dataflowTemplate string,
 	appProfileID string,
+	maxNumWorkers string,
 ) error {
 	// Flex templates are json based templates.
 	// Please see the README under java/dataflow in this repo.
@@ -66,7 +67,7 @@ func LaunchDataflowJob(
 		return launchFromFlexTemplate(
 			ctx, projectID, instance, tableID,
 			dataPath, controlPath, dataflowTemplate,
-			appProfileID,
+			appProfileID, maxNumWorkers,
 		)
 	}
 
@@ -74,7 +75,7 @@ func LaunchDataflowJob(
 	return launchFromClassicTemplate(
 		ctx, projectID, instance, tableID,
 		dataPath, controlPath, dataflowTemplate,
-		appProfileID,
+		appProfileID, maxNumWorkers,
 	)
 }
 
@@ -94,6 +95,7 @@ func launchFromFlexTemplate(
 	controlPath string,
 	dataflowTemplate string,
 	appProfileID string,
+	maxNumWorkers string,
 ) error {
 	dataflowService, err := dataflow.NewService(ctx)
 	if err != nil {
@@ -116,13 +118,14 @@ func launchFromFlexTemplate(
 	params := &dataflow.LaunchFlexTemplateParameter{
 		JobName: jobName,
 		Parameters: map[string]string{
-			"inputFile":            dataFile,
-			"completionFile":       completedPath,
-			"bigtableInstanceId":   instance,
-			"bigtableTableId":      tableID,
-			"bigtableProjectId":    projectID,
-			"tempLocation":         tempLocation,
-			"bigtableAppProfileId": appProfileID,
+			"inputFile":             dataFile,
+			"completionFile":        completedPath,
+			"bigtableInstanceId":    instance,
+			"bigtableTableId":       tableID,
+			"bigtableProjectId":     projectID,
+			"tempLocation":          tempLocation,
+			"bigtableAppProfileId":  appProfileID,
+			"bigtableMaxNumWorkers": maxNumWorkers,
 		},
 		ContainerSpecGcsPath: dataflowTemplate,
 	}
@@ -154,6 +157,7 @@ func launchFromClassicTemplate(
 	controlPath string,
 	dataflowTemplate string,
 	appProfileID string,
+	maxNumWorkers string,
 ) error {
 	dataflowService, err := dataflow.NewService(ctx)
 	if err != nil {
@@ -165,13 +169,14 @@ func launchFromClassicTemplate(
 	params := &dataflow.LaunchTemplateParameters{
 		JobName: tableID,
 		Parameters: map[string]string{
-			"inputFile":            dataFile,
-			"completionFile":       completedPath,
-			"bigtableInstanceId":   instance,
-			"bigtableTableId":      tableID,
-			"bigtableProjectId":    projectID,
-			"region":               region,
-			"bigtableAppProfileId": appProfileID,
+			"inputFile":             dataFile,
+			"completionFile":        completedPath,
+			"bigtableInstanceId":    instance,
+			"bigtableTableId":       tableID,
+			"bigtableProjectId":     projectID,
+			"region":                region,
+			"bigtableAppProfileId":  appProfileID,
+			"bigtableMaxNumWorkers": maxNumWorkers,
 		},
 	}
 	log.Printf("[%s/%s] Launching dataflow job: %s -> %s\n", instance, tableID, dataFile, launchedPath)


### PR DESCRIPTION
This is because the latest SDK (2.53.0) was causing the infrequent load to fail (leading to increased latency and other production issues). Limiting the workers is to help manage the CPU usage, which spikes during load jobs.