### PR TITLE
update footnotes in answers

### DIFF
--- a/llm/data_gemma/datacommons.py
+++ b/llm/data_gemma/datacommons.py
@@ -27,11 +27,14 @@ from data_gemma import utils
 
 _BASE_URL = 'https://{env}.datacommons.org/nodejs/query'
 
+_POINT_MODE = 'toolformer_rig'
+_TABLE_MODE = 'toolformer_rag'
+
 # Do not allow topics, use higher threshold (0.8).
-_POINT_PARAMS = 'allCharts=1&mode=toolformer_rig&idx=base_uae_mem'
+_POINT_PARAMS = f'allCharts=1&mode={_POINT_MODE}&idx=base_uae_mem'
 
 # Allow topics, use lower threshold (0.7).
-_TABLE_PARAMS = 'mode=toolformer_rag&client=table&idx=base_uae_mem'
+_TABLE_PARAMS = f'mode={_TABLE_MODE}&client=table&idx=base_uae_mem'
 
 
 class DataCommons:
@@ -82,6 +85,8 @@ class DataCommons:
     score = svm.get('CosineScore', [-1])[0]
     var = svm.get('SV', [''])[0]
     url = chart.get('dcUrl', '')
+    if url:
+      url += f'&mode={_POINT_MODE}'
     return base.DataCommonsCall(
         query=query,
         val=v,
@@ -127,6 +132,8 @@ class DataCommons:
     score = svm.get('CosineScore', [-1])[0]
     var = svm.get('SV', [''])[0]
     url = chart.get('dcUrl', '')
+    if url:
+      url += f'&mode={_TABLE_MODE}'
     return base.DataCommonsCall(
         query=query,
         unit=u,


### PR DESCRIPTION
when nl mode=toolformer_[rig/rag], the results can be slightly different than default mode (e.g., global is understood as world, different threshold for returning variables, how topics are opened, etc). When linking to datacommons in the footnotes, we should link to the right mode, otherwise the results may be different than what is shown in the answer.

e.g., Has the use of renewables increased in the world?
current: 
```
...
#### FOOTNOTES ####
[1] - Per Global SDG Database, value was 18.71 Percentage in 2021. See more at https://datacommons.org/explore#q=what%20percentage%20of%20global%20energy%20comes%20from%20renewables%3F
[2] - Per Global SDG Database, value was 16.87 Percentage in 2000. See more at https://datacommons.org/explore#q=what%20percentage%20of%20global%20energy%20came%20from%20renewables%20in%202000%3F
```
with change: 
```
...
#### FOOTNOTES #### 
[1] - Per Global SDG Database, value was 18.71 Percentage in 2021. See more at https://datacommons.org/explore#q=what%20percentage%20of%20global%20energy%20comes%20from%20renewables%3F&mode=toolformer_rig 
[2] - Per Global SDG Database, value was 16.87 Percentage in 2000. See more at https://datacommons.org/explore#q=what%20percentage%20of%20global%20energy%20came%20from%20renewables%20in%202000%3F&mode=toolformer_rig
```