### PR TITLE
[Data Weaver] Rename DATACOMMONS_API_KEY to DATA_COMMONS_API_KEY in deployment configurations

### DIFF
--- a/dataweaver/cloudbuild.dataweaver.yaml
+++ b/dataweaver/cloudbuild.dataweaver.yaml
@@ -32,7 +32,7 @@ steps:
       - '--iap'
       - '--service-account'
       - 'data-weaver-sa-mj@datcom-website-sandbox.iam.gserviceaccount.com'
-      - '--update-secrets=TLDRAW_LICENSE_KEY=tldraw-license-key:latest,DATACOMMONS_API_KEY=datacommons-api-key:latest,GEMINI_API_KEY=gemini-api-key:latest'
+      - '--update-secrets=TLDRAW_LICENSE_KEY=tldraw-license-key:latest,DATA_COMMONS_API_KEY=datacommons-api-key:latest,GEMINI_API_KEY=gemini-api-key:latest'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/dataweaver/deploy.sh
+++ b/dataweaver/deploy.sh
@@ -35,4 +35,4 @@ gcloud run deploy dataweaver-dev \
   --no-allow-unauthenticated \
   --iap \
   --service-account data-weaver-sa-mj@datcom-website-sandbox.iam.gserviceaccount.com \
-  --update-secrets=TLDRAW_LICENSE_KEY=tldraw-license-key:latest,DATACOMMONS_API_KEY=datacommons-api-key:latest,GEMINI_API_KEY=gemini-api-key:latest
+  --update-secrets=TLDRAW_LICENSE_KEY=tldraw-license-key:latest,DATA_COMMONS_API_KEY=datacommons-api-key:latest,GEMINI_API_KEY=gemini-api-key:latest


### PR DESCRIPTION
## Description

This PR renames the environment variable mapping for the Data Commons API key from `DATACOMMONS_API_KEY` to `DATA_COMMONS_API_KEY` in the following deployment configuration files:
* `dataweaver/deploy.sh`
* `dataweaver/cloudbuild.dataweaver.yaml`

This aligns the deployment configurations with the application code (e.g., client libraries) which references the environment variable using the name `DATA_COMMONS_API_KEY`. 