### PR TITLE
Scott/error hookup

### DIFF
--- a/dataweaver/apps/web/src/app/api/query/route.ts
+++ b/dataweaver/apps/web/src/app/api/query/route.ts
@@ -162,13 +162,11 @@ export async function POST(request: NextRequest) {
             });
             continue;
           }
-
           // Parse model response into query results
           emit({
             type: STREAM_EVENT.status,
             message: STATUS.buildingResults(placeLabel),
           });
-
           let parsedResponse: QueryModelResponse | undefined;
           try {
             parsedResponse = extractJson<QueryModelResponse>(responseText);
@@ -185,19 +183,15 @@ export async function POST(request: NextRequest) {
             });
             continue;
           }
-
           const variables = parsedResponse.variables || [];
           if (variables.length === 0) {
             emit({
-              type: STREAM_EVENT.status,
-              message:
-                parsedResponse.introduction || STATUS.noVariables(placeLabel),
+              type: STREAM_EVENT.error,
+              message: STATUS.noVariables(placeLabel),
             });
             continue;
           }
-
           const entityDcid = parsedResponse.placeDcid || resolvedPlaceDcid;
-
           if (!entityDcid) {
             emit({
               type: STREAM_EVENT.status,
@@ -215,7 +209,6 @@ export async function POST(request: NextRequest) {
           const timeSeries = await Promise.all(
             variables.map((v) => fetchTimeSeries(v.dcid, entityDcid, signal)),
           );
-
           const discoveryResult: QueryResult = {
             id: nanoid(),
             title:

--- a/dataweaver/apps/web/src/app/api/query/route.ts
+++ b/dataweaver/apps/web/src/app/api/query/route.ts
@@ -124,7 +124,14 @@ export async function POST(request: NextRequest) {
           if (signal.aborted) break;
 
           const place = places[i];
-          if (!place?.trim()) continue;
+          if (!place?.trim()) {
+            emit({
+              type: STREAM_EVENT.placeSkipped,
+              place: place ?? '',
+              reason: 'Empty place name',
+            });
+            continue;
+          }
 
           const placeLabel = parsed.titles[place] || place;
           emit({
@@ -157,8 +164,9 @@ export async function POST(request: NextRequest) {
           if (signal.aborted) break;
           if (!responseText) {
             emit({
-              type: STREAM_EVENT.status,
-              message: STATUS.noResponse(placeLabel),
+              type: STREAM_EVENT.placeSkipped,
+              place,
+              reason: STATUS.noResponse(placeLabel),
             });
             continue;
           }
@@ -178,24 +186,27 @@ export async function POST(request: NextRequest) {
             }
           } catch {
             emit({
-              type: STREAM_EVENT.status,
-              message: STATUS.invalidResponse(placeLabel),
+              type: STREAM_EVENT.placeSkipped,
+              place,
+              reason: STATUS.invalidResponse(placeLabel),
             });
             continue;
           }
           const variables = parsedResponse.variables || [];
           if (variables.length === 0) {
             emit({
-              type: STREAM_EVENT.error,
-              message: STATUS.noVariables(placeLabel),
+              type: STREAM_EVENT.placeSkipped,
+              place,
+              reason: STATUS.noVariables(placeLabel),
             });
             continue;
           }
           const entityDcid = parsedResponse.placeDcid || resolvedPlaceDcid;
           if (!entityDcid) {
             emit({
-              type: STREAM_EVENT.status,
-              message: STATUS.invalidDcid(placeLabel),
+              type: STREAM_EVENT.placeSkipped,
+              place,
+              reason: STATUS.invalidDcid(placeLabel),
             });
             continue;
           }

--- a/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
@@ -117,6 +117,7 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
       const decoder = new TextDecoder();
       let buffer = '';
 
+      let isTerminalReached = false;
       const handleEvent = (event: StreamEvent) => {
         if (controller.signal.aborted) return;
 
@@ -125,6 +126,7 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
             setState((prev) => ({ ...prev, status: event.message }));
             break;
           case STREAM_EVENT.complete:
+            isTerminalReached = true;
             setState((prev) => ({
               ...prev,
               status: STATUS.complete,
@@ -132,6 +134,7 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
             }));
             break;
           case STREAM_EVENT.error:
+            isTerminalReached = true;
             setState((prev) => ({
               ...prev,
               error: event.message,
@@ -164,17 +167,16 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
         }
       }
 
-      if (!controller.signal.aborted) {
-        setState((prev) => {
-          if (prev.isComplete) return prev;
-          // Stream ended without a complete/error event — synthesize one
-          // so the provider always receives a terminal signal.
-          onEventRef.current?.({
-            type: STREAM_EVENT.complete,
-            message: STATUS.complete,
-          });
-          return { ...prev, status: STATUS.complete, isComplete: true };
+      if (!controller.signal.aborted && !isTerminalReached) {
+        onEventRef.current?.({
+          type: STREAM_EVENT.complete,
+          message: STATUS.complete,
         });
+        setState((prev) => ({
+          ...prev,
+          status: STATUS.complete,
+          isComplete: true,
+        }));
       }
     } catch (err: unknown) {
       const error =

--- a/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from '~/components/foundations/toaster/store';
 import {
   type QueryStreamRequest,
   STATUS,
@@ -93,9 +94,11 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
 
       if (!res.ok) {
         const errBody = await res.text();
+        const errorMessage = STATUS.apiError(res.status, errBody);
+        toast('Query failed', errorMessage);
         setState((prev) => ({
           ...prev,
-          error: STATUS.apiError(res.status, errBody),
+          error: errorMessage,
           isComplete: true,
         }));
         return;
@@ -176,6 +179,7 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
           : null;
 
       if (error && error.name !== 'AbortError') {
+        toast('Connection error', error.message);
         setState((prev) => ({
           ...prev,
           error: error.message,

--- a/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { toast } from '~/components/foundations/toaster/store';
 import {
   type QueryStreamRequest,
   STATUS,
@@ -94,24 +93,12 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
 
       if (!res.ok) {
         const errBody = await res.text();
-        const errorMessage = STATUS.apiError(res.status, errBody);
-        toast('Query failed', errorMessage);
-        setState((prev) => ({
-          ...prev,
-          error: errorMessage,
-          isComplete: true,
-        }));
-        return;
+        throw new Error(STATUS.apiError(res.status, errBody));
       }
 
       const reader = res.body?.getReader();
       if (!reader) {
-        setState((prev) => ({
-          ...prev,
-          error: STATUS.noResponseBody,
-          isComplete: true,
-        }));
-        return;
+        throw new Error(STATUS.noResponseBody);
       }
 
       const decoder = new TextDecoder();
@@ -188,7 +175,6 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
           : null;
 
       if (error && error.name !== 'AbortError') {
-        toast('Connection error', error.message);
         // Synthesize an error event so the provider can clean up store state.
         onEventRef.current?.({
           type: STREAM_EVENT.error,

--- a/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/hooks/use_streaming_query.ts
@@ -47,7 +47,7 @@ const parseSSEChunk = (
         const event: StreamEvent = JSON.parse(dataLine);
         events.push(event);
       } catch {
-        // Skip malformed events
+        console.warn('[SSE] Malformed event data, skipping:', dataLine);
       }
     }
   }
@@ -165,9 +165,16 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
       }
 
       if (!controller.signal.aborted) {
-        setState((prev) =>
-          prev.isComplete ? prev : { ...prev, isComplete: true },
-        );
+        setState((prev) => {
+          if (prev.isComplete) return prev;
+          // Stream ended without a complete/error event — synthesize one
+          // so the provider always receives a terminal signal.
+          onEventRef.current?.({
+            type: STREAM_EVENT.complete,
+            message: STATUS.complete,
+          });
+          return { ...prev, status: STATUS.complete, isComplete: true };
+        });
       }
     } catch (err: unknown) {
       const error =
@@ -180,6 +187,11 @@ export const useStreamingQuery = (onEvent?: StreamEventHandler) => {
 
       if (error && error.name !== 'AbortError') {
         toast('Connection error', error.message);
+        // Synthesize an error event so the provider can clean up store state.
+        onEventRef.current?.({
+          type: STREAM_EVENT.error,
+          message: error.message,
+        });
         setState((prev) => ({
           ...prev,
           error: error.message,

--- a/dataweaver/apps/web/src/components/scopes/atlas/query_provider.tsx
+++ b/dataweaver/apps/web/src/components/scopes/atlas/query_provider.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import { toast } from '~/components/foundations/toaster/store';
 import { useAtlas } from '~/components/scopes/atlas/atlas_provider';
 import { useStreamingQuery } from '~/components/scopes/atlas/hooks/use_streaming_query';
 import type { CardEntry, StreamEvent } from '~/server/types';
@@ -139,6 +140,7 @@ export const QueryProvider = ({ children }: QueryProviderProps) => {
         break;
 
       case STREAM_EVENT.error:
+        toast('Query failed', event.message);
         queryFail(active.nodeId);
         querySetProcessing(false);
         querySetStatus(STATUS.idle);

--- a/dataweaver/apps/web/src/components/scopes/atlas/query_provider.tsx
+++ b/dataweaver/apps/web/src/components/scopes/atlas/query_provider.tsx
@@ -155,13 +155,6 @@ export const QueryProvider = ({ children }: QueryProviderProps) => {
 
       case STREAM_EVENT.error: {
         toast('Query failed', event.message);
-
-        // Remove any cards created during this query (e.g. loading placeholders).
-        const { cardUnregister } = store.getState();
-        for (const id of active.cardIds) {
-          cardUnregister(id);
-        }
-
         queryFail(active.nodeId);
         querySetProcessing(false);
         querySetStatus(STATUS.idle);

--- a/dataweaver/apps/web/src/components/scopes/atlas/query_provider.tsx
+++ b/dataweaver/apps/web/src/components/scopes/atlas/query_provider.tsx
@@ -132,20 +132,53 @@ export const QueryProvider = ({ children }: QueryProviderProps) => {
         break;
       }
 
-      case STREAM_EVENT.complete:
-        queryComplete(active.nodeId, active.cardIds);
+      case STREAM_EVENT.complete: {
+        // Defensive cleanup: remove any orphan loading cards that were never
+        // resolved (e.g. if a placeSkipped event was somehow missed).
+        const { cardUnregister: unregisterOrphan, cards } = store.getState();
+        const remaining: string[] = [];
+        for (const id of active.cardIds) {
+          const card = cards[id];
+          if (card?.type === 'loading') {
+            unregisterOrphan(id);
+          } else {
+            remaining.push(id);
+          }
+        }
+
+        queryComplete(active.nodeId, remaining);
         querySetProcessing(false);
         querySetStatus(event.message);
         activeQueryRef.current = null;
         break;
+      }
 
-      case STREAM_EVENT.error:
+      case STREAM_EVENT.error: {
         toast('Query failed', event.message);
+
+        // Remove any cards created during this query (e.g. loading placeholders).
+        const { cardUnregister } = store.getState();
+        for (const id of active.cardIds) {
+          cardUnregister(id);
+        }
+
         queryFail(active.nodeId);
         querySetProcessing(false);
         querySetStatus(STATUS.idle);
         activeQueryRef.current = null;
         break;
+      }
+
+      case STREAM_EVENT.placeSkipped: {
+        // Remove the loading placeholder for this skipped place.
+        const loadingId = `shape:${active.nodeId}__${event.place}__loading`;
+        const { cardUnregister: unregisterSkipped } = store.getState();
+        unregisterSkipped(loadingId);
+        active.cardIds = active.cardIds.filter((id) => id !== loadingId);
+        toast('Place skipped', event.reason);
+        querySetStatus(event.reason);
+        break;
+      }
     }
   }, []);
 

--- a/dataweaver/apps/web/src/components/scopes/page_home/page_home.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/page_home.tsx
@@ -32,7 +32,10 @@ export const PageHome = () => {
     if (Object.values(nodes).length > 0) setIsIntroVisible(false);
   }, [nodes]);
 
-  const showStatus = !isIntroVisible && currentStatus !== STATUS.complete;
+  const showStatus =
+    !isIntroVisible &&
+    currentStatus !== STATUS.complete &&
+    currentStatus !== STATUS.idle;
 
   return (
     <div className={s.container}>

--- a/dataweaver/apps/web/src/server/clients/mcp.ts
+++ b/dataweaver/apps/web/src/server/clients/mcp.ts
@@ -20,6 +20,12 @@ export const callMcp = async <T = unknown>(
     params,
   };
 
+  // Combine caller's abort signal with a 30s timeout so MCP calls don't hang.
+  const timeoutMs = 30_000;
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])
+    : AbortSignal.timeout(timeoutMs);
+
   const res = await fetch(mcpEndpoint, {
     method: 'POST',
     headers: {
@@ -28,7 +34,7 @@ export const callMcp = async <T = unknown>(
       'X-API-Key': apiKey,
     },
     body: JSON.stringify(payload),
-    signal,
+    signal: combinedSignal,
   });
 
   if (!res.ok) {

--- a/dataweaver/apps/web/src/server/steps/data_discovery.ts
+++ b/dataweaver/apps/web/src/server/steps/data_discovery.ts
@@ -156,11 +156,19 @@ export const runToolLoop = async (
           max: maxToolCalls,
         });
 
-        const toolResult = await callMcp<McpToolCallResult>(
-          'tools/call',
-          { name: fcName, arguments: fc?.args },
-          signal,
-        );
+        let toolResult: McpToolCallResult;
+        try {
+          toolResult = await callMcp<McpToolCallResult>(
+            'tools/call',
+            { name: fcName, arguments: fc?.args },
+            signal,
+          );
+        } catch (err: unknown) {
+          // If the caller aborted, re-throw so the outer loop exits cleanly.
+          if (signal?.aborted) throw err;
+          // Tool call timed out or failed — return empty so the place is skipped.
+          return { text: '', resolvedPlaceDcid };
+        }
 
         // Extract place DCID from search_indicators responses
         if (fcName === 'search_indicators' && !resolvedPlaceDcid) {

--- a/dataweaver/apps/web/src/server/steps/parse_query.ts
+++ b/dataweaver/apps/web/src/server/steps/parse_query.ts
@@ -35,7 +35,9 @@ export const parseQuery = async (
   });
 
   const responseText = response.text || '';
+
   const parsed = extractJson<ParsedQuery>(responseText);
+
   return parsed
     ? {
         places: Array.isArray(parsed.places) ? parsed.places : [query],

--- a/dataweaver/apps/web/src/server/types.ts
+++ b/dataweaver/apps/web/src/server/types.ts
@@ -149,6 +149,7 @@ export const STREAM_EVENT = {
   parsedQuery: 'parsed_query',
   toolCall: 'tool_call',
   queryResult: 'query_result',
+  placeSkipped: 'place_skipped',
   complete: 'complete',
   error: 'error',
 } as const;
@@ -166,5 +167,6 @@ export type StreamEvent =
       result: QueryResult;
       place: string;
     }
+  | { type: typeof STREAM_EVENT.placeSkipped; place: string; reason: string }
   | { type: typeof STREAM_EVENT.complete; message: string }
   | { type: typeof STREAM_EVENT.error; message: string };

--- a/dataweaver/apps/web/src/store/store.ts
+++ b/dataweaver/apps/web/src/store/store.ts
@@ -149,11 +149,19 @@ export const useAtlasStore = create<AtlasStore>()(
             (state) => {
               const node = state.nodes[nodeId];
               if (!node) return state;
+
+              const remainingCards = Object.fromEntries(
+                Object.entries(state.cards).filter(
+                  ([, card]) => card.historyNodeId !== nodeId,
+                ),
+              );
+
               return {
                 nodes: {
                   ...state.nodes,
                   [nodeId]: { ...node, status: 'error' },
                 },
+                cards: remainingCards,
               };
             },
             undefined,


### PR DESCRIPTION
## Overview

Hooks up error handling and failure states to the existing toast notification system, and ensures cards stuck in a loading state are properly cleaned up when places are skipped or queries fail. Previously, when an MCP tool call timed out, returned no data, or produced an unparseable response, the UI would silently swallow the error and leave loading placeholders indefinitely. This PR introduces a new `place_skipped` stream event, surfaces errors via toasts, and adds defensive cleanup on query completion/failure.

## Changes Made

- [x] Introduced a new `place_skipped` SSE stream event type to distinguish skipped places from generic status messages
- [x] Hooked up toast notifications for API errors, connection errors, and skipped places in `use_streaming_query` and `query_provider`
- [x] Added defensive cleanup in the `complete` event handler to unregister orphan loading cards that were never resolved
- [x] Added cleanup in the `error` event handler to remove all cards created during a failed query
- [x] Added a 30-second timeout to MCP tool calls (`callMcp`) so they don't hang indefinitely
- [x] Wrapped MCP `tools/call` in a try/catch in `data_discovery` to gracefully handle timeouts/failures instead of crashing the loop
- [x] Synthesized terminal stream events (`complete`/`error`) when the stream ends unexpectedly so the provider always receives a final signal
- [x] Fixed status bar remaining visible after query completion by also hiding on `STATUS.idle`
- [x] `queryFail` store action now removes associated cards for the failed node

## TODO

While this PR cleans up the experience by showing errors and cleaning up cards that are stuck, most of these situations might be better handled by having the agent asking follow-up questions to the user -- To be discussed and handed in a later PR