### PR TITLE
remove 2px padding from top & bottom of notice container

### DIFF
--- a/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
@@ -64,7 +64,7 @@
   grid-area: notice;
   column-gap: 4px;
   align-items: center;
-  padding: 20px 28px;
+  padding: 18px 28px;
   color: rgb(var(--color-query-content));
   background: rgb(var(--color-query-surface-subtle));
 


### PR DESCRIPTION
## Overview

Removes padding from intro card footer

From tracker:
"Intro card footer - The footer in the intro card seems too high for what it is. Let's make it more tight by removing 2 px from the top and bottom"
