### PR TITLE
[Data Weaver] Build fix

### DIFF
--- a/dataweaver/Dockerfile
+++ b/dataweaver/Dockerfile
@@ -17,7 +17,7 @@ COPY packages/tokens/package.json ./packages/tokens/
 COPY apps/web/package.json ./apps/web/
 
 # Install dependencies
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 
 # Rebuild the source code only when needed
@@ -35,6 +35,7 @@ COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
 COPY . .
 
 # Build the project
+RUN pnpm run generate:tokens
 RUN pnpm build
 
 # Production image, copy all the files and run next

--- a/dataweaver/Dockerfile
+++ b/dataweaver/Dockerfile
@@ -19,6 +19,7 @@ COPY apps/web/package.json ./apps/web/
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
+
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app

--- a/dataweaver/package.json
+++ b/dataweaver/package.json
@@ -5,16 +5,17 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "pnpm run generate:tokens && pnpm -r --parallel dev",
-    "build": "pnpm run generate:tokens && pnpm -r build",
+    "dev": "pnpm -r --parallel dev",
+    "build": "pnpm -r build",
     "preview": "pnpm -r --parallel preview",
-    "lint": "pnpm run generate:tokens && pnpm -r run lint:type-check && pnpm run lint:biome && pnpm run lint:styles",
+    "lint": "pnpm -r run lint:type-check && pnpm run lint:biome && pnpm run lint:styles",
     "lint:biome": "biome check",
     "lint:styles": "stylelint \"**/*.scss\"",
     "fix": "pnpm run fix:biome && pnpm run fix:styles",
     "fix:biome": "biome check --write --unsafe",
     "fix:styles": "stylelint \"**/*.scss\" --fix",
-    "generate:tokens": "pnpm --filter @package/tokens generate"
+    "generate:tokens": "pnpm --filter @package/tokens generate",
+    "prepare": "pnpm run generate:tokens"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/dataweaver/package.json
+++ b/dataweaver/package.json
@@ -5,17 +5,16 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "pnpm -r --parallel dev",
-    "build": "pnpm -r build",
+    "dev": "pnpm run generate:tokens && pnpm -r --parallel dev",
+    "build": "pnpm run generate:tokens && pnpm -r build",
     "preview": "pnpm -r --parallel preview",
-    "lint": "pnpm -r run lint:type-check && pnpm run lint:biome && pnpm run lint:styles",
+    "lint": "pnpm run generate:tokens && pnpm -r run lint:type-check && pnpm run lint:biome && pnpm run lint:styles",
     "lint:biome": "biome check",
     "lint:styles": "stylelint \"**/*.scss\"",
     "fix": "pnpm run fix:biome && pnpm run fix:styles",
     "fix:biome": "biome check --write --unsafe",
     "fix:styles": "stylelint \"**/*.scss\" --fix",
-    "generate:tokens": "pnpm --filter @package/tokens generate",
-    "prepare": "pnpm run generate:tokens"
+    "generate:tokens": "pnpm --filter @package/tokens generate"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",


### PR DESCRIPTION
## Description

This PR fixes a Docker build failure caused by executing token generation during the dependency installation phase.

- Removed the `"prepare"` script hook from the root `package.json`. This prevents token generation from triggering during `pnpm install` (i.e. triggering too early in the Docker build, when source files are not yet copied).
- Prepended `pnpm run generate:tokens` to the `"dev"`, `"build"`, and `"lint"` scripts in the root `package.json`.

## Testing
To verify the changes locally:

### Verify build and lint orchestration:
   Clear any existing generated tokens:
   `rm -rf packages/tokens/dist`

Run the lint or build script:
`pnpm lint`

### Verify Docker build

`docker build -t dataweaver -f Dockerfile .`

### Dev Branch

I verified the dataweaver-dev branch is now building.