### PR TITLE
Implement App Wide UI Improvements

### DIFF
--- a/dataweaver/FRONTEND.md
+++ b/dataweaver/FRONTEND.md
@@ -244,8 +244,6 @@ skip layout/paint).
 - **Don't restate the reset.** `styles/core/_reset.scss` already neutralises
   margins, `button` chrome, `a` decoration, list bullets, etc. Check it before
   adding `padding: 0` / `border: 0` / `background: none`.
-- Override focus offset via `--outline-offset` (`-default` 2px / `-inset` -3px);
-  never override `outline` itself.
 - Typography mixins live in `~/styles/typography.module.scss` — `@use` it where
   needed (it isn't part of the auto-injected includes).
 - Cascade layers, low → high: `reset, root, base, primitive` (`~/styles/layers.css`).

--- a/dataweaver/apps/web/src/components/elements/button.module.scss
+++ b/dataweaver/apps/web/src/components/elements/button.module.scss
@@ -78,53 +78,27 @@
     &[data-size="small"] {
       column-gap: 2px;
       min-height: var(--button-pill-size-small);
+      padding-inline: 12px;
       border-radius: calc(var(--button-pill-size-small) / 2);
-
-      &[data-has-icon="false"] {
-        padding-inline: 16px;
-      }
-
-      &[data-has-icon="true"] {
-        padding-inline: 10px 16px;
-      }
     }
 
     &[data-size="medium"] {
       column-gap: 4px;
       min-height: var(--button-pill-size-medium);
+      padding-inline: 15px;
       border-radius: calc(var(--button-pill-size-medium) / 2);
-
-      &[data-has-icon="false"] {
-        padding-inline: 16px;
-      }
-
-      &[data-has-icon="true"] {
-        padding-inline: 16px 18px;
-      }
     }
 
     &[data-size="large"] {
       column-gap: 6px;
       min-height: var(--button-pill-size-large);
+      padding-inline: 18px;
       border-radius: calc(var(--button-pill-size-large) / 2);
-
-      &[data-has-icon="false"] {
-        padding-inline: 16px;
-      }
-
-      &[data-has-icon="true"] {
-        padding-inline: 22px 24px;
-      }
     }
   }
 
   &[data-shape="circle"] {
     border-radius: 50%;
-
-    &[data-size="extra-small"] {
-      width: var(--button-circle-size-extra-small);
-      height: var(--button-circle-size-extra-small);
-    }
 
     &[data-size="small"] {
       width: var(--button-circle-size-small);
@@ -139,6 +113,11 @@
     &[data-size="large"] {
       width: var(--button-circle-size-large);
       height: var(--button-circle-size-large);
+    }
+
+    &[data-size="extra-large"] {
+      width: var(--button-circle-size-extra-large);
+      height: var(--button-circle-size-extra-large);
     }
   }
 
@@ -174,36 +153,26 @@
 
 .icon {
   flex-shrink: 0;
-
-  [data-size="extra-small"] & {
-    width: 12px;
-    height: 12px;
-  }
-
-  [data-size="small"] &,
-  [data-size="medium"] &,
-  [data-size="large"] & {
-    width: 24px;
-    height: 24px;
-  }
+  width: 20px;
+  height: 20px;
 }
 
 .children {
   [data-size="small"] & {
     @include type-label-small;
 
-    padding-block: 8px;
+    padding-block: 6px;
   }
 
   [data-size="medium"] & {
     @include type-label-medium;
 
-    padding-block: 12px;
+    padding-block: 8px;
   }
 
   [data-size="large"] & {
     @include type-label-large;
 
-    padding-block: 14px;
+    padding-block: 10px;
   }
 }

--- a/dataweaver/apps/web/src/components/elements/button.tsx
+++ b/dataweaver/apps/web/src/components/elements/button.tsx
@@ -64,7 +64,6 @@ export const Button = ({
       data-size={size}
       data-variant={variant}
       data-tone={tone}
-      data-has-icon={Icon !== undefined}
       disabled={isDisabled}
     >
       {Icon && <Icon className={s.icon} />}

--- a/dataweaver/apps/web/src/components/elements/button.tsx
+++ b/dataweaver/apps/web/src/components/elements/button.tsx
@@ -21,7 +21,7 @@ interface WithExternalTones {
 
 interface WithIconOnly {
   icon: ComponentType<ComponentPropsWithRef<'svg'>>;
-  size: 'extra-small' | 'small' | 'medium' | 'large';
+  size: 'small' | 'medium' | 'large' | 'extra-large';
   'aria-label': string;
   children?: never;
 }

--- a/dataweaver/apps/web/src/components/elements/card/base.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/base.module.scss
@@ -35,6 +35,7 @@
   height: fit-content;
   max-height: 100%;
   overflow-y: auto;
+  overscroll-behavior: none;
   scrollbar-width: thin;
   background: rgb(var(--color-card-surface));
   border: var(--border-thickness) solid transparent;

--- a/dataweaver/apps/web/src/components/elements/card/base.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/base.module.scss
@@ -1,5 +1,4 @@
 .container {
-  --actions-height: 48px;
   --corner-size: 16px;
   --border-thickness: 2px;
 

--- a/dataweaver/apps/web/src/components/elements/card/base.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/base.module.scss
@@ -35,6 +35,7 @@
   height: fit-content;
   max-height: 100%;
   overflow-y: auto;
+  scrollbar-width: thin;
   background: rgb(var(--color-card-surface));
   border: var(--border-thickness) solid transparent;
   border-radius: var(--corner-size);

--- a/dataweaver/apps/web/src/components/elements/card/base.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/base.tsx
@@ -57,7 +57,7 @@ export const CardBase = ({
           <Button
             key={index}
             icon={action.icon}
-            size="medium"
+            size="large"
             variant="flat"
             tone="card-action"
             aria-label={action.label}

--- a/dataweaver/apps/web/src/components/elements/card/chart/menu_chart_options.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/chart/menu_chart_options.module.scss
@@ -61,5 +61,5 @@
   display: flex;
   gap: 8px;
   justify-content: flex-end;
-  padding: 32px 18px 20px 0;
+  padding: 28px 16px 18px 0;
 }

--- a/dataweaver/apps/web/src/components/elements/radio.module.scss
+++ b/dataweaver/apps/web/src/components/elements/radio.module.scss
@@ -41,8 +41,8 @@
   }
 
   &:focus-visible:focus + .indicator {
-    outline: 1px dashed currentcolor;
-    outline-offset: var(--outline-offset);
+    outline: 1.5px solid rgb(var(--color-outline));
+    outline-offset: 2px;
   }
 }
 

--- a/dataweaver/apps/web/src/components/elements/tag.module.scss
+++ b/dataweaver/apps/web/src/components/elements/tag.module.scss
@@ -3,19 +3,11 @@
   column-gap: 8px;
   align-items: center;
   height: var(--tag-height);
+  padding-inline: 12px;
   color: rgb(var(--color-tag-content));
   border: 1px solid rgb(var(--color-tag-border));
   border-radius: 14px;
   box-shadow: var(--shadow-subtle);
-
-  &[data-has-icon="false"] {
-    padding-inline: 12px;
-  }
-
-  &[data-has-icon="true"] {
-    // Note: The extra 1px here accounts for the 1px border
-    padding-inline: 12px 4px;
-  }
 }
 
 .label {

--- a/dataweaver/apps/web/src/components/elements/tag.tsx
+++ b/dataweaver/apps/web/src/components/elements/tag.tsx
@@ -1,27 +1,13 @@
-import { IconClose } from '~/components/primitives/icons/close';
-import { Button } from './button';
 import s from './tag.module.scss';
 
 interface TagProps {
   label: string;
-  onRemove?: () => void;
 }
 
-export const Tag = ({ label, onRemove }: TagProps) => {
+export const Tag = ({ label }: TagProps) => {
   return (
-    <span className={s.container} data-has-icon={onRemove !== undefined}>
+    <span className={s.container}>
       <span className={s.label}>{label}</span>
-
-      {onRemove && (
-        <Button
-          size="extra-small"
-          variant="flat"
-          tone="subtle"
-          icon={IconClose}
-          aria-label={`Remove ${label}`}
-          onClick={onRemove}
-        />
-      )}
     </span>
   );
 };

--- a/dataweaver/apps/web/src/components/foundations/toaster/toaster.module.scss
+++ b/dataweaver/apps/web/src/components/foundations/toaster/toaster.module.scss
@@ -49,8 +49,6 @@
 }
 
 .button-dismiss {
-  --outline-offset: var(--outline-offset-inset);
-
   grid-area: 1 / 1;
   border-radius: inherit;
 }

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/export/menu.tsx
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/export/menu.tsx
@@ -57,7 +57,7 @@ export const Menu = ({ id, onClose }: MenuProps) => {
         <Button
           icon={IconClose}
           className={s['button-close']}
-          size="medium"
+          size="large"
           variant="flat"
           tone="subtle"
           aria-label="Close export"

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/history.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/history.module.scss
@@ -1,6 +1,6 @@
 .container {
   display: flex;
-  column-gap: 10px;
+  column-gap: 8px;
   align-items: center;
   justify-content: space-between;
   height: var(--controls-height);
@@ -13,7 +13,7 @@
 
   .divider {
     width: 1px;
-    height: 30px;
+    height: var(--button-circle-size-medium);
     background: rgb(var(--color-control-divider));
   }
 }

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/history.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/history.module.scss
@@ -1,11 +1,10 @@
 .container {
   display: flex;
-  column-gap: 8px;
+  column-gap: 10px;
   align-items: center;
   justify-content: space-between;
   height: var(--controls-height);
-  padding: 0
-    calc((var(--controls-height) - var(--button-circle-size-medium)) / 2);
+  padding: 0 5px;
   color: rgb(var(--color-control-accent));
   background: rgb(var(--color-control-surface));
   border-radius: calc(var(--controls-height) / 2);

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/history.tsx
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/history.tsx
@@ -15,7 +15,7 @@ export const History = () => {
     <div className={s.container} role="toolbar" aria-label="History">
       <Button
         icon={IconUndo}
-        size="medium"
+        size="small"
         variant="flat"
         tone="subtle-highlight"
         aria-label="Undo"
@@ -27,7 +27,7 @@ export const History = () => {
 
       <Button
         icon={IconRedo}
-        size="medium"
+        size="small"
         variant="flat"
         tone="subtle-highlight"
         aria-label="Redo"

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection.module.scss
@@ -16,8 +16,8 @@
   gap: 6px;
   align-items: center;
   justify-content: center;
-  height: 50px;
-  padding: 0 50px;
+  height: var(--actions-height);
+  padding: 0 40px;
   pointer-events: auto;
   background: rgb(var(--color-control-accent));
   border-radius: var(--border-radius-medium);

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection.tsx
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection.tsx
@@ -74,7 +74,7 @@ export const Selection = () => {
           >
             <Button
               icon={IconBarChartOutlined}
-              size="medium"
+              size="large"
               variant="flat"
               tone="card-action"
               aria-label="View chart"
@@ -90,7 +90,7 @@ export const Selection = () => {
             />
             <Button
               icon={IconExport}
-              size="medium"
+              size="large"
               variant="flat"
               tone="card-action"
               aria-label="Export"
@@ -99,7 +99,7 @@ export const Selection = () => {
             />
             <Button
               icon={IconDelete}
-              size="medium"
+              size="large"
               variant="flat"
               tone="card-action"
               aria-label="Delete"

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/tools.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/tools.module.scss
@@ -4,7 +4,7 @@
   right: var(--tools-gutter-outer);
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  row-gap: 16px;
   align-items: center;
   width: var(--tools-width);
   padding: var(--tools-gutter-inner);

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/zoom/control.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/zoom/control.module.scss
@@ -3,7 +3,7 @@
   gap: 2px;
   align-items: center;
   height: var(--controls-height);
-  padding: 0 8px;
+  padding: 0 5px;
   color: rgb(var(--color-control-accent));
   background: rgb(var(--color-control-surface));
   border-radius: calc(var(--controls-height) / 2);

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/zoom/control.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/zoom/control.module.scss
@@ -12,8 +12,8 @@
   .button-value {
     @include type-label-large;
 
-    width: 60px;
-    height: 28px;
+    width: 48px;
+    height: var(--button-circle-size-small);
     color: rgb(var(--color-control-accent));
     text-align: center;
     border-radius: var(--border-radius-small);

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/zoom/menu.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/zoom/menu.module.scss
@@ -30,7 +30,7 @@
     }
 
     .label {
-      @include type-label-medium;
+      @include type-label-large;
 
       color: rgb(var(--color-control-content));
     }

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
@@ -11,10 +11,8 @@
 }
 
 .outer-container {
-  overflow-y: auto;
-  overscroll-behavior: none;
-  pointer-events: auto;
-  scrollbar-width: thin;
+  display: grid;
+  overflow: clip;
   background:
     linear-gradient(
         rgb(var(--color-query-surface-subtle)),
@@ -38,6 +36,14 @@
   @include prefers-motion {
     animation: border-rotate 6s linear infinite;
   }
+}
+
+.middle-container {
+  height: 100%;
+  overflow-y: auto;
+  overscroll-behavior: none;
+  pointer-events: auto;
+  scrollbar-width: thin;
 }
 
 .inner-container {

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
@@ -1,41 +1,9 @@
-@property --border-angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
-}
-
-@keyframes border-rotate {
-  to {
-    --border-angle: 360deg;
-  }
-}
-
 .outer-container {
   display: grid;
   overflow: clip;
-  background:
-    linear-gradient(
-        rgb(var(--color-query-surface-subtle)),
-        rgb(var(--color-query-surface-subtle))
-      )
-      padding-box,
-    conic-gradient(
-        from var(--border-angle),
-        rgb(var(--color-query-accent)),
-        rgb(var(--color-query-accent-subtle)),
-        rgb(var(--color-query-accent)),
-        rgb(var(--color-query-accent-subtle)),
-        rgb(var(--color-query-accent))
-      )
-      border-box;
-  border: 1.5px solid transparent;
+  background: rgb(var(--color-query-surface-raised));
   border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-elevated);
-
-  // Animate the registered custom property to rotate the border gradient
-  @include prefers-motion {
-    animation: border-rotate 6s linear infinite;
-  }
 }
 
 .middle-container {

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
@@ -11,7 +11,6 @@
 }
 
 .outer-container {
-  width: 100%;
   overflow-y: auto;
   overscroll-behavior: none;
   pointer-events: auto;
@@ -41,33 +40,49 @@
 }
 
 .inner-container {
+  display: grid;
+  grid-template-areas:
+    "content close"
+    "notice notice";
+  grid-template-columns: 1fr min-content;
+  padding-top: 18px;
+}
+
+.button-close {
+  grid-area: close;
+  margin-right: 18px;
+}
+
+.content-container {
   display: flex;
   flex-direction: column;
-  row-gap: 32px;
-  padding: 40px;
-}
+  grid-area: content;
+  row-gap: 30px;
+  padding: 16px 0 32px 32px;
 
-.question {
-  @include type-body-large(500);
+  .question {
+    @include type-body-large(500);
 
-  align-self: flex-end;
-  max-width: 80%;
-  padding: 20px 28px;
-  color: rgb(var(--color-query-content-subtle));
-  background: rgb(var(--color-query-surface-muted));
-  border-radius: var(--border-radius-medium);
-}
+    width: fit-content;
+    max-width: 90%;
+    min-height: 44px;
+    padding: 9px 16px;
+    color: rgb(var(--color-query-content-subtle));
+    background: rgb(var(--color-query-surface-muted));
+    border-radius: 22px;
+  }
 
-.answer {
-  @include type-body-large;
+  .answer {
+    @include type-body-large;
 
-  color: rgb(var(--color-query-content-subtle));
-  white-space: break-spaces;
-}
+    color: rgb(var(--color-query-content-subtle));
+    white-space: break-spaces;
+  }
 
-.prompts-container {
-  display: flex;
-  flex-direction: column;
-  row-gap: 8px;
-  align-items: flex-start;
+  .prompts-container {
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
+    align-items: flex-start;
+  }
 }

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
@@ -14,6 +14,7 @@
   overflow-y: auto;
   overscroll-behavior: none;
   pointer-events: auto;
+  scrollbar-width: thin;
   background:
     linear-gradient(
         rgb(var(--color-query-surface-subtle)),

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
@@ -48,9 +48,7 @@
 
 .inner-container {
   display: grid;
-  grid-template-areas:
-    "content close"
-    "notice notice";
+  grid-template-areas: "content close";
   grid-template-columns: 1fr min-content;
   padding-top: 18px;
 }

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.module.scss
@@ -62,8 +62,8 @@
   display: flex;
   flex-direction: column;
   grid-area: content;
-  row-gap: 30px;
-  padding: 16px 0 32px 32px;
+  row-gap: 24px;
+  padding: 16px 0 32px 24px;
 
   .question {
     @include type-body-large(500);

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.tsx
@@ -3,6 +3,7 @@
 import { EASE_LINEAR } from '@package/tokens/ts';
 import { m } from 'motion/react';
 import { Button } from '~/components/elements/button';
+import { IconClose } from '~/components/primitives/icons/close';
 import type { FollowUp as FollowUpData } from '~/server/types';
 import s from './follow_up.module.scss';
 
@@ -10,9 +11,15 @@ interface FollowUpProps {
   prompt: string;
   followUp: FollowUpData;
   onSelect: (followUp: string) => void;
+  onClose: () => void;
 }
 
-export const FollowUp = ({ prompt, followUp, onSelect }: FollowUpProps) => {
+export const FollowUp = ({
+  prompt,
+  followUp,
+  onSelect,
+  onClose,
+}: FollowUpProps) => {
   return (
     <m.section
       className={s['outer-container']}
@@ -22,27 +29,39 @@ export const FollowUp = ({ prompt, followUp, onSelect }: FollowUpProps) => {
       transition={{ duration: 0.1, ease: EASE_LINEAR }}
     >
       <div className={s['inner-container']}>
-        <p className={s.question}>{prompt}</p>
+        <Button
+          className={s['button-close']}
+          icon={IconClose}
+          size="large"
+          variant="flat"
+          tone="subtle"
+          aria-label="Close"
+          onClick={onClose}
+        />
 
-        <div className={s.answer}>{followUp.summary}</div>
-        <div className={s.answer}>{followUp.question}</div>
+        <div className={s['content-container']}>
+          <p className={s.question}>{prompt}</p>
 
-        {followUp?.options?.length > 0 && (
-          <ul className={s['prompts-container']}>
-            {followUp.options.map((option) => (
-              <li key={option}>
-                <Button
-                  size="medium"
-                  variant="flat"
-                  tone="accent-subtle"
-                  onClick={() => onSelect(option)}
-                >
-                  {option}
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
+          <div className={s.answer}>{followUp.summary}</div>
+          <div className={s.answer}>{followUp.question}</div>
+
+          {followUp?.options?.length > 0 && (
+            <ul className={s['prompts-container']}>
+              {followUp.options.map((option) => (
+                <li key={option}>
+                  <Button
+                    size="medium"
+                    variant="flat"
+                    tone="accent-subtle"
+                    onClick={() => onSelect(option)}
+                  >
+                    {option}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
     </m.section>
   );

--- a/dataweaver/apps/web/src/components/scopes/page_home/follow_up.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/follow_up.tsx
@@ -28,39 +28,41 @@ export const FollowUp = ({
       exit={{ opacity: 0 }}
       transition={{ duration: 0.1, ease: EASE_LINEAR }}
     >
-      <div className={s['inner-container']}>
-        <Button
-          className={s['button-close']}
-          icon={IconClose}
-          size="large"
-          variant="flat"
-          tone="subtle"
-          aria-label="Close"
-          onClick={onClose}
-        />
+      <div className={s['middle-container']}>
+        <div className={s['inner-container']}>
+          <Button
+            className={s['button-close']}
+            icon={IconClose}
+            size="large"
+            variant="flat"
+            tone="subtle"
+            aria-label="Close"
+            onClick={onClose}
+          />
 
-        <div className={s['content-container']}>
-          <p className={s.question}>{prompt}</p>
+          <div className={s['content-container']}>
+            <p className={s.question}>{prompt}</p>
 
-          <div className={s.answer}>{followUp.summary}</div>
-          <div className={s.answer}>{followUp.question}</div>
+            <div className={s.answer}>{followUp.summary}</div>
+            <div className={s.answer}>{followUp.question}</div>
 
-          {followUp?.options?.length > 0 && (
-            <ul className={s['prompts-container']}>
-              {followUp.options.map((option) => (
-                <li key={option}>
-                  <Button
-                    size="medium"
-                    variant="flat"
-                    tone="accent-subtle"
-                    onClick={() => onSelect(option)}
-                  >
-                    {option}
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          )}
+            {followUp?.options?.length > 0 && (
+              <ul className={s['prompts-container']}>
+                {followUp.options.map((option) => (
+                  <li key={option}>
+                    <Button
+                      size="medium"
+                      variant="flat"
+                      tone="accent-subtle"
+                      onClick={() => onSelect(option)}
+                    >
+                      {option}
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
       </div>
     </m.section>

--- a/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
@@ -2,6 +2,7 @@
   overflow-y: auto;
   overscroll-behavior: none;
   pointer-events: auto;
+  scrollbar-width: thin;
   background: rgb(var(--color-query-surface-raised));
   border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-elevated);
@@ -13,20 +14,20 @@
     "content close"
     "notice notice";
   grid-template-columns: 1fr min-content;
-  padding-top: 20px;
+  padding-top: 18px;
 }
 
 .button-close {
   grid-area: close;
-  margin-right: 20px;
+  margin-right: 18px;
 }
 
 .content-container {
   display: flex;
   flex-direction: column;
   grid-area: content;
-  row-gap: 32px;
-  padding: 20px 0 40px 32px;
+  row-gap: 30px;
+  padding: 16px 0 32px 32px;
 
   .title {
     @include type-display;
@@ -64,7 +65,7 @@
   grid-area: notice;
   column-gap: 4px;
   align-items: center;
-  padding: 18px 28px;
+  padding: 16px 28px;
   color: rgb(var(--color-query-content));
   background: rgb(var(--color-query-surface-subtle));
 

--- a/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
@@ -1,11 +1,18 @@
 .outer-container {
+  display: grid;
+  overflow: clip;
+  pointer-events: auto;
+  background: rgb(var(--color-query-surface-raised));
+  border-radius: var(--border-radius-large);
+  box-shadow: var(--shadow-elevated);
+}
+
+.middle-container {
+  height: 100%;
   overflow-y: auto;
   overscroll-behavior: none;
   pointer-events: auto;
   scrollbar-width: thin;
-  background: rgb(var(--color-query-surface-raised));
-  border-radius: var(--border-radius-large);
-  box-shadow: var(--shadow-elevated);
 }
 
 .inner-container {

--- a/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
@@ -33,13 +33,13 @@
   display: flex;
   flex-direction: column;
   grid-area: content;
-  row-gap: 30px;
+  row-gap: 24px;
   padding: 16px 0 32px 24px;
 
   .title {
     @include type-display;
 
-    max-width: 540px;
+    max-width: 420px;
     color: rgb(var(--color-query-content-subtle));
   }
 

--- a/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/intro.module.scss
@@ -34,7 +34,7 @@
   flex-direction: column;
   grid-area: content;
   row-gap: 30px;
-  padding: 16px 0 32px 32px;
+  padding: 16px 0 32px 24px;
 
   .title {
     @include type-display;

--- a/dataweaver/apps/web/src/components/scopes/page_home/intro.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/intro.tsx
@@ -26,53 +26,55 @@ export const Intro = ({ onSelect, onClose }: IntroProps) => {
       exit={{ opacity: 0 }}
       transition={{ duration: 0.1, ease: EASE_LINEAR }}
     >
-      <div className={s['inner-container']}>
-        <Button
-          className={s['button-close']}
-          icon={IconClose}
-          size="large"
-          variant="flat"
-          tone="subtle"
-          aria-label="Close"
-          onClick={onClose}
-        />
+      <div className={s['middle-container']}>
+        <div className={s['inner-container']}>
+          <Button
+            className={s['button-close']}
+            icon={IconClose}
+            size="large"
+            variant="flat"
+            tone="subtle"
+            aria-label="Close"
+            onClick={onClose}
+          />
 
-        <div className={s['content-container']}>
-          <h2 className={s.title}>
-            Let's discover what you can do with Data Commons
-          </h2>
+          <div className={s['content-container']}>
+            <h2 className={s.title}>
+              Let's discover what you can do with Data Commons
+            </h2>
 
-          <p className={s.description}>
-            Explore data visually on an infinite canvas with your AI thought
-            partner. Find, visualize, and understand rich data from Data Commons
-            to deepen your research exploration.
+            <p className={s.description}>
+              Explore data visually on an infinite canvas with your AI thought
+              partner. Find, visualize, and understand rich data from Data
+              Commons to deepen your research exploration.
+            </p>
+
+            <p className={s.question}>
+              Ask Data Weaver your research question, or try examples like:
+            </p>
+
+            <ul className={s['examples-container']}>
+              {EXAMPLE_PROMPTS.map((example, index) => (
+                <li key={example}>
+                  <Button
+                    size="medium"
+                    variant="flat"
+                    tone="accent-subtle"
+                    onClick={() => onSelect(example, index)}
+                  >
+                    {example}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <p className={s['notice-container']}>
+            <IconInfo className={s['icon-info']} aria-hidden="true" />
+            This tool currently does not save your progress. Please export
+            before closing tab to retain data.
           </p>
-
-          <p className={s.question}>
-            Ask Data Weaver your research question, or try examples like:
-          </p>
-
-          <ul className={s['examples-container']}>
-            {EXAMPLE_PROMPTS.map((example, index) => (
-              <li key={example}>
-                <Button
-                  size="medium"
-                  variant="flat"
-                  tone="accent-subtle"
-                  onClick={() => onSelect(example, index)}
-                >
-                  {example}
-                </Button>
-              </li>
-            ))}
-          </ul>
         </div>
-
-        <p className={s['notice-container']}>
-          <IconInfo className={s['icon-info']} aria-hidden="true" />
-          This tool currently does not save your progress. Please export before
-          closing tab to retain data.
-        </p>
       </div>
     </m.section>
   );

--- a/dataweaver/apps/web/src/components/scopes/page_home/intro.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/intro.tsx
@@ -30,7 +30,7 @@ export const Intro = ({ onSelect, onClose }: IntroProps) => {
         <Button
           className={s['button-close']}
           icon={IconClose}
-          size="medium"
+          size="large"
           variant="flat"
           tone="subtle"
           aria-label="Close"

--- a/dataweaver/apps/web/src/components/scopes/page_home/page_home.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/page_home.module.scss
@@ -1,5 +1,5 @@
 .container {
-  --gutter: 40px;
+  --gutter: 32px;
   --buffer: 12px;
   --controls-height-with-gutters: calc(
     var(--controls-height) + var(--controls-gutter-outer) * 2
@@ -7,15 +7,22 @@
   --tools-width-with-gutters: calc(
     var(--tools-width) + var(--tools-gutter-outer) * 2
   );
+  --distance-from-right: calc(var(--tools-width-with-gutters) + var(--buffer));
+  --distance-from-left: var(--gutter);
 
   position: fixed;
-  right: calc(var(--tools-width-with-gutters) + var(--buffer));
+  right: var(--distance-from-right);
   bottom: var(--gutter);
+  left: var(--distance-from-left);
   z-index: $z-index-above-content;
   display: flex;
   flex-direction: column;
-  row-gap: var(--gutter);
+  row-gap: 16px;
+  justify-self: flex-end;
   width: 696px;
+  max-width: calc(
+    100% - var(--distance-from-left) - var(--distance-from-right)
+  );
   max-height: calc(
     100dvh - var(--gutter) - var(--controls-height-with-gutters) - var(--buffer)
   );

--- a/dataweaver/apps/web/src/components/scopes/page_home/page_home.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/page_home.tsx
@@ -60,6 +60,7 @@ export const PageHome = () => {
           .map((r) => r.followUp)
           .filter(Boolean)
       : [];
+
     // TODO - we currently can get more than one follow-up, as the api will return
     // one per place in the query. Here I'm just using the first one, but we'll need to figure
     // out a better way to handle this
@@ -88,6 +89,7 @@ export const PageHome = () => {
             prompt={query}
             followUp={followUp}
             onSelect={submitPrompt}
+            onClose={() => setFollowUp(null)}
           />
         )}
 

--- a/dataweaver/apps/web/src/components/scopes/page_home/page_home.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/page_home.tsx
@@ -36,6 +36,12 @@ export const PageHome = () => {
 
   const [isIntroVisible, setIsIntroVisible] = useState(true);
   const [followUp, setFollowUp] = useState<FollowUpData | null>(null);
+
+  // TODO: Explore if we can drop dismissed node ID by improving how FollowUp
+  // 'onClose' handles the follow-up state. Currently, if a user dismisses a
+  // follow-up and then the same node is re-run, the follow-up will reappear.
+  // This state here is a workaround to prevent that for now
+  const [dismissedNodeId, setDismissedNodeId] = useState<string | null>(null);
   const [promptValue, setPromptValue] = useState('');
 
   const submitPrompt = (value = promptValue) => {
@@ -65,12 +71,17 @@ export const PageHome = () => {
     // one per place in the query. Here I'm just using the first one, but we'll need to figure
     // out a better way to handle this
     const firstFollowUp = followUps[0];
-    if (latestNode && firstFollowUp && currentStatus === STATUS.complete) {
+    if (
+      latestNode &&
+      firstFollowUp &&
+      currentStatus === STATUS.complete &&
+      latestNode.id !== dismissedNodeId
+    ) {
       setFollowUp(firstFollowUp);
     } else {
       setFollowUp(null);
     }
-  }, [currentStatus, latestNode]);
+  }, [currentStatus, latestNode, dismissedNodeId]);
 
   return (
     <div className={s.container}>
@@ -89,7 +100,10 @@ export const PageHome = () => {
             prompt={query}
             followUp={followUp}
             onSelect={submitPrompt}
-            onClose={() => setFollowUp(null)}
+            onClose={() => {
+              setFollowUp(null);
+              if (latestNode) setDismissedNodeId(latestNode.id);
+            }}
           />
         )}
 

--- a/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
@@ -1,14 +1,65 @@
+@property --border-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes border-rotate {
+  to {
+    --border-angle: 360deg;
+  }
+}
+
 .container {
-  display: flex;
-  flex-shrink: 0;
-  flex-direction: column;
-  row-gap: 24px;
+  display: grid;
   width: 100%;
-  padding: 28px 24px 16px;
   pointer-events: auto;
   background: rgb(var(--color-query-surface-raised));
   border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-elevated);
+
+  &::before {
+    grid-area: 1 / 1;
+    padding: 1.5px;
+    pointer-events: none;
+    content: "";
+    background: conic-gradient(
+      from var(--border-angle),
+      rgb(var(--color-query-accent)),
+      rgb(var(--color-query-accent-subtle)),
+      rgb(var(--color-query-accent)),
+      rgb(var(--color-query-accent-subtle)),
+      rgb(var(--color-query-accent))
+    );
+    border-radius: inherit;
+    opacity: 0;
+
+    // Punch out the interior so only the 1.5px padding ring shows the gradient
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask-composite: exclude;
+
+    @include prefers-motion {
+      transition: opacity 0.2s $ease-linear;
+
+      // Paused while hidden; only runs while the input is focused
+      animation: border-rotate 6s linear infinite paused;
+    }
+  }
+
+  &:has(.input:focus)::before {
+    opacity: 1;
+    animation-play-state: running;
+  }
+}
+
+.content-container {
+  display: flex;
+  flex-direction: column;
+  grid-area: 1 / 1;
+  row-gap: 24px;
+  padding: 28px 24px 16px;
 }
 
 .input {

--- a/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
@@ -14,12 +14,14 @@
 .input {
   --max-rows: 4;
 
-  @include type-body-large(500);
+  @include type-body-large;
 
   width: 100%;
   max-height: calc(var(--max-rows) * 1lh);
   overflow-y: auto;
   color: rgb(var(--color-query-content));
+  caret-color: rgb(var(--color-query-accent));
+  outline: none;
   field-sizing: content;
 
   // Support manual resizing if content-based sizing isn't supported
@@ -28,7 +30,7 @@
   }
 
   &::placeholder {
-    color: rgb(var(--color-query-content-subtle));
+    color: rgb(var(--color-query-content-dimmed));
   }
 }
 

--- a/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
@@ -22,6 +22,7 @@
   color: rgb(var(--color-query-content));
   caret-color: rgb(var(--color-query-accent));
   outline: none;
+  scrollbar-width: thin;
   field-sizing: content;
 
   // Support manual resizing if content-based sizing isn't supported

--- a/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
@@ -14,7 +14,7 @@
 .input {
   --max-rows: 4;
 
-  @include type-label-large(false);
+  @include type-body-large(500);
 
   width: 100%;
   max-height: calc(var(--max-rows) * 1lh);

--- a/dataweaver/apps/web/src/components/scopes/page_home/prompt.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/prompt.tsx
@@ -92,7 +92,7 @@ export const Prompt = ({
         <Button
           className={s['button-submit']}
           type="submit"
-          size="medium"
+          size="extra-large"
           variant="border"
           tone="prominent"
           icon={IconArrowUp}

--- a/dataweaver/apps/web/src/components/scopes/page_home/prompt.tsx
+++ b/dataweaver/apps/web/src/components/scopes/page_home/prompt.tsx
@@ -48,57 +48,59 @@ export const Prompt = ({
         submitted();
       }}
     >
-      <ScreenReaderOnly element="label" htmlFor={inputId}>
-        {PROMPT_PLACEHOLDER}
-      </ScreenReaderOnly>
+      <div className={s['content-container']}>
+        <ScreenReaderOnly element="label" htmlFor={inputId}>
+          {PROMPT_PLACEHOLDER}
+        </ScreenReaderOnly>
 
-      <textarea
-        id={inputId}
-        className={s.input}
-        value={value}
-        rows={1}
-        placeholder={PROMPT_PLACEHOLDER}
-        onChange={(event) => onValueChange(event.target.value)}
-        onKeyDown={(event) => {
-          // Submit if enter is pressed without shift or during IME composition
-          if (
-            event.key === 'Enter' &&
-            !event.shiftKey &&
-            !event.nativeEvent.isComposing
-          ) {
-            event.preventDefault();
-            submitted();
-          }
-        }}
-      />
-
-      <div className={s['button-row-container']}>
-        <ul className={s['tags-container']}>
-          <AnimatePresence initial={false} mode="wait">
-            {tags.map((tag) => (
-              <m.li
-                key={tag.id}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.2, ease: EASE_LINEAR }}
-              >
-                <Tag label={tag.title} />
-              </m.li>
-            ))}
-          </AnimatePresence>
-        </ul>
-
-        <Button
-          className={s['button-submit']}
-          type="submit"
-          size="extra-large"
-          variant="border"
-          tone="prominent"
-          icon={IconArrowUp}
-          aria-label="Submit prompt"
-          isDisabled={!hasValue}
+        <textarea
+          id={inputId}
+          className={s.input}
+          value={value}
+          rows={1}
+          placeholder={PROMPT_PLACEHOLDER}
+          onChange={(event) => onValueChange(event.target.value)}
+          onKeyDown={(event) => {
+            // Submit if enter is pressed without shift or during IME composition
+            if (
+              event.key === 'Enter' &&
+              !event.shiftKey &&
+              !event.nativeEvent.isComposing
+            ) {
+              event.preventDefault();
+              submitted();
+            }
+          }}
         />
+
+        <div className={s['button-row-container']}>
+          <ul className={s['tags-container']}>
+            <AnimatePresence initial={false} mode="wait">
+              {tags.map((tag) => (
+                <m.li
+                  key={tag.id}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.2, ease: EASE_LINEAR }}
+                >
+                  <Tag label={tag.title} />
+                </m.li>
+              ))}
+            </AnimatePresence>
+          </ul>
+
+          <Button
+            className={s['button-submit']}
+            type="submit"
+            size="extra-large"
+            variant="border"
+            tone="prominent"
+            icon={IconArrowUp}
+            aria-label="Submit prompt"
+            isDisabled={!hasValue}
+          />
+        </div>
       </div>
     </form>
   );

--- a/dataweaver/apps/web/src/components/scopes/page_home/status.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/status.module.scss
@@ -1,9 +1,9 @@
 .container {
   display: grid;
   grid-template-columns: 1fr min-content;
-  gap: 32px 16px;
+  gap: 28px 16px;
   width: 100%;
-  padding: 32px 26px;
+  padding: 26px 24px;
   pointer-events: auto;
   background: rgb(var(--color-query-surface-subtle));
   border-radius: var(--border-radius-large);
@@ -14,7 +14,7 @@
   @include type-body-large(500);
 
   grid-row: 1;
-  grid-column: 1;
+  grid-column: 1 / span 2;
   color: rgb(var(--color-query-content-subtle));
 }
 
@@ -27,7 +27,7 @@
 }
 
 .button-cancel {
-  grid-row: 1 / span 2;
+  grid-row: 2;
   grid-column: 2;
   align-self: flex-end;
 }

--- a/dataweaver/apps/web/src/styles/core/_base.scss
+++ b/dataweaver/apps/web/src/styles/core/_base.scss
@@ -11,7 +11,7 @@
   }
 
   *:focus-visible:focus {
-    outline: 2px solid currentcolor;
+    outline: 1.5px solid currentcolor;
     outline-offset: var(--outline-offset);
   }
 }

--- a/dataweaver/apps/web/src/styles/core/_base.scss
+++ b/dataweaver/apps/web/src/styles/core/_base.scss
@@ -12,6 +12,6 @@
 
   *:focus-visible:focus {
     outline: 1.5px solid rgb(var(--color-outline));
-    outline-offset: var(--outline-offset);
+    outline-offset: 2px;
   }
 }

--- a/dataweaver/apps/web/src/styles/core/_base.scss
+++ b/dataweaver/apps/web/src/styles/core/_base.scss
@@ -11,7 +11,7 @@
   }
 
   *:focus-visible:focus {
-    outline: 1px dashed currentcolor;
+    outline: 2px solid currentcolor;
     outline-offset: var(--outline-offset);
   }
 }

--- a/dataweaver/apps/web/src/styles/core/_base.scss
+++ b/dataweaver/apps/web/src/styles/core/_base.scss
@@ -11,7 +11,7 @@
   }
 
   *:focus-visible:focus {
-    outline: 1.5px solid currentcolor;
+    outline: 1.5px solid rgb(var(--color-outline));
     outline-offset: var(--outline-offset);
   }
 }

--- a/dataweaver/apps/web/src/styles/core/_root.scss
+++ b/dataweaver/apps/web/src/styles/core/_root.scss
@@ -8,23 +8,24 @@
     --shadow-elevated:
       0 1px 3px 1px rgb(var(--color-shadow) / 15%),
       0 1px 2px rgb(var(--color-shadow) / 30%);
-    --button-pill-size-small: 28px;
-    --button-pill-size-medium: 42px;
-    --button-pill-size-large: 46px;
-    --button-circle-size-extra-small: 20px;
-    --button-circle-size-small: 28px;
-    --button-circle-size-medium: 40px;
-    --button-circle-size-large: 48px;
+    --button-pill-size-small: 27px;
+    --button-pill-size-medium: 32px;
+    --button-pill-size-large: 34px;
+    --button-circle-size-small: 25px;
+    --button-circle-size-medium: 28px;
+    --button-circle-size-large: 32px;
+    --button-circle-size-extra-large: 34px;
     --tag-height: 27px;
     --controls-gutter-outer: 16px;
     --controls-height: var(--button-pill-size-large);
     --tools-gutter-outer: 16px;
-    --tools-gutter-inner: 8px;
+    --tools-gutter-inner: 6px;
     --tools-width: calc(
       var(--button-circle-size-large) + var(--tools-gutter-inner) * 2
     );
     --border-radius-large: 32px;
     --border-radius-medium: 16px;
     --border-radius-small: 8px;
+    --actions-height: calc(var(--button-circle-size-large) + 10px);
   }
 }

--- a/dataweaver/apps/web/src/styles/core/_root.scss
+++ b/dataweaver/apps/web/src/styles/core/_root.scss
@@ -2,9 +2,6 @@
 
 @layer root {
   :root {
-    --outline-offset-default: 2px;
-    --outline-offset-inset: -3px;
-    --outline-offset: var(--outline-offset-default);
     --shadow-elevated:
       0 1px 3px 1px rgb(var(--color-shadow) / 15%),
       0 1px 2px rgb(var(--color-shadow) / 30%);

--- a/dataweaver/apps/web/src/styles/includes/_typography.module.scss
+++ b/dataweaver/apps/web/src/styles/includes/_typography.module.scss
@@ -74,7 +74,7 @@ $-supported-body-font-weights: 400, 500;
 }
 
 @mixin type-label-large($has-text-box-trim: true) {
-  font-size: 20px;
+  font-size: 16px;
   font-weight: 500;
   line-height: 1.4;
 
@@ -84,7 +84,7 @@ $-supported-body-font-weights: 400, 500;
 }
 
 @mixin type-label-medium($has-text-box-trim: true) {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 1.4;
 

--- a/dataweaver/packages/tokens/src/colors.json
+++ b/dataweaver/packages/tokens/src/colors.json
@@ -16,6 +16,7 @@
 
   "shadow": [0, 0, 0],
   "transparent": [0, 0, 0, 0],
+  "outline": [0, 0, 0],
 
   "atlas-surface": "$surface-dimmed",
   "atlas-decorator": "$surface-muted",


### PR DESCRIPTION
## Overview

### Button tweaks
- New `extra-large` size and removed `extra-small` (shifted the icon-only size range up).
- Simplified pill/tag padding - dropped `data-has-icon`.
- Fixed icon size (20×20) instead of per-size sizing; tightened `padding-block` across sizes.
- Bumped many buttons from `medium` → `large` (card actions, selection toolbar, export/intro close buttons) and the prompt submit to `extra-large`.

### Design token resizing (`_root.scss`)
- Shrunk all button pill/circle size tokens.
- Reduced `--tools-gutter-inner` and introduced a shared `--actions-height` token - now reused by the card and selection toolbar.
- Reduced `type-label-large` and `type-label-medium`.

### Intro & Follow-up panels
- Follow-up now has a close button (`onClose` wired through `page_home`) and was restructured to match Intro's grid layout (middle/inner/content containers, styled question bubble).
- Both refactored to a `middle-container` scroll wrapper with `overflow: clip` outer + `scrollbar-width: thin`, replacing outer-container scrolling. This fixes scrollbar appearing outside container.
- Tightened paddings/gaps throughout.

### Layout & scrolling
- `page_home` container now anchors left+right with a `max-width` for some basic mobile responsivness support.
- Added thin scrollbars (`scrollbar-width: thin`) and `overscroll-behavior: none` across card content, prompt input, intro/follow-up.
- Status panel: title spans both columns + tighter padding/gaps.

### Prompt input
- Switched to `type-body-large`, added accent caret color, removed outline, dimmer placeholder color.
- Implement animated border when input is active (ported from follow-up panel and dropped in latter).

### Tag simplification
- Removed the removable/`onRemove` close-button variant — `Tag` is now label-only with uniform padding.

### Misc
- Focus ring changed from `1px dashed` → `1.5px solid` with a new fixed `outline` token color.
- Various control tweaks (history divider, zoom control/menu sizing and label size).

## Screenshots

### Intro screen
Before:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/87b1f614-b1c8-414f-bcbf-fa716de0076e" />
After:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/e44e214f-c374-4e41-b7c0-27d2486e8f83" />

### Status and zoom menu
Before:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/0666f9ac-f882-40c3-ae98-e29d7020e569" />
After:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/12598b03-51fd-4344-a4bf-158818b77a89" />

### Follow-up
Before:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/05bd573e-780f-44b4-bfd8-29aba9176587" />
After:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/39c49bdc-a47f-45da-b8c5-87789f2b3538" />

### Export menu
Before:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/963bd08c-ef2d-40a5-8f24-079536247838" />
After:
<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/7518e9d2-113b-4d64-9c19-19d8e90f471b" />

### Animated Input
https://github.com/user-attachments/assets/b5c8c385-840f-4b31-b1f4-21209f609e9e