### PR TITLE
add top margin to facet selector

### DIFF
--- a/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-shrink: 0;
   gap: 8px;
-  margin-bottom: 12px;
+  margin-block: 12px;
 }
 
 .prefix {


### PR DESCRIPTION
## Overview

Tiny fix to chart card styling -- the recent card resizing PR removed padding after the card description which added space before the facet selector. This just re-adds that space.