### PR TITLE
restyle facet dropdown to match figma

### DIFF
--- a/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
@@ -1,9 +1,10 @@
 .container {
   position: relative;
-  display: flex;
+  display: grid;
   flex-shrink: 0;
   gap: 8px;
   margin-block: 18px;
+  color: rgb(var(--color-facet-selector-color));
   background: rgb(var(--color-facet-selector-surface));
   border-radius: var(--border-radius-extra-small);
   box-shadow: 0 0 0 1px rgb(var(--color-facet-selector-border));
@@ -12,15 +13,14 @@
 .prefix {
   @include type-body-small;
 
-  position: absolute;
-  top: 0;
-  left: 0;
   display: flex;
   flex-shrink: 0;
+  grid-area: 1 / 1;
   gap: 0;
+  place-self: start;
   align-items: flex-start;
   font-weight: 500;
-  color: rgb(var(--color-card-content-muted));
+  color: rgb(var(--color-facet-selector-prefix));
   background: rgb(var(--color-facet-selector-surface));
   box-shadow: 0 0 0 3px rgb(var(--color-facet-selector-surface));
   transform: translate(16px, -50%);
@@ -31,14 +31,12 @@
   @include type-body-medium;
 
   display: flex;
+  grid-area: 1 / 1;
   gap: 16px;
   align-items: center;
   justify-content: space-between;
   width: 100%;
   padding: 12px 16px;
-  color: rgb(var(--color-facet-selector-color));
-  background: none;
-  border: none;
 }
 
 .trigger {
@@ -56,7 +54,7 @@
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 100;
+  z-index: $z-index-above-content;
   width: 100%;
   min-width: 280px;
   margin-top: 5px;
@@ -80,12 +78,12 @@
   background: transparent;
 
   &[data-is-selected="true"] {
-    background: rgb(var(--color-button-accent-subtle-base));
+    background: rgb(var(--color-facet-selector-option-selected));
   }
 
   &:not([data-is-selected="true"]) {
     @include hover {
-      background: rgb(var(--color-button-accent-subtle-base-hover));
+      background: rgb(var(--color-facet-selector-option-hover));
     }
   }
 }

--- a/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
@@ -3,43 +3,51 @@
   display: flex;
   flex-shrink: 0;
   gap: 8px;
-  margin-block: 12px;
+  margin-block: 18px;
+  background: rgb(var(--color-facet-selector-surface));
+  border-radius: var(--border-radius-extra-small);
+  box-shadow: 0 0 0 1px rgb(var(--color-facet-selector-border));
 }
 
 .prefix {
-  @include type-label-small;
+  @include type-body-small;
 
+  position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   flex-shrink: 0;
   gap: 0;
   align-items: flex-start;
   font-weight: 500;
   color: rgb(var(--color-card-content-muted));
+  background: rgb(var(--color-facet-selector-surface));
+  box-shadow: 0 0 0 3px rgb(var(--color-facet-selector-surface));
+  transform: translate(16px, -50%);
 }
 
+.trigger,
 .label {
-  @include type-label-small;
+  @include type-body-medium;
 
-  color: rgb(var(--color-card-content-muted));
-}
-
-.trigger {
-  @include type-label-small;
-
-  display: inline-flex;
-  gap: 4px;
+  display: flex;
+  gap: 16px;
   align-items: center;
-  padding: 0;
-  font-weight: 500;
-  color: rgb(var(--color-card-base-selected));
-  cursor: pointer;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  color: rgb(var(--color-facet-selector-color));
   background: none;
   border: none;
 }
 
+.trigger {
+  cursor: pointer;
+}
+
 .arrow {
   flex-shrink: 0;
-  place-self: start;
+  place-self: center end;
   font-size: 14px;
   line-height: 16.4px;
 }
@@ -51,49 +59,33 @@
   z-index: 100;
   width: 100%;
   min-width: 280px;
-  margin-top: 4px;
+  margin-top: 5px;
   overflow: hidden;
-  background: rgb(var(--color-card-surface));
-  border-radius: var(--border-radius-small);
+  background: rgb(var(--color-facet-selector-surface));
+  border-radius: var(--border-radius-extra-small);
   box-shadow: var(--shadow-elevated);
 }
 
 .option {
+  @include type-body-medium;
+
   display: flex;
   flex-direction: column;
   gap: 8px;
   width: 100%;
-  padding: 8px 12px;
+  padding: 12px 16px;
+  color: rgb(var(--color-facet-selector-color));
   text-align: left;
   cursor: pointer;
   background: transparent;
-  border: none;
-  border-bottom: 1px solid rgb(var(--color-surface-decorator));
-
-  &:last-child {
-    border-bottom: none;
-  }
 
   &[data-is-selected="true"] {
-    background: rgb(var(--color-control-accent) / 12%);
+    background: rgb(var(--color-button-accent-subtle-base));
   }
 
   &:not([data-is-selected="true"]) {
     @include hover {
-      background: rgb(var(--color-control-accent) / 6%);
+      background: rgb(var(--color-button-accent-subtle-base-hover));
     }
   }
-}
-
-.option-source {
-  @include type-label-small;
-
-  font-weight: 500;
-  color: rgb(var(--color-card-content));
-}
-
-.option-meta {
-  @include type-label-small;
-
-  color: rgb(var(--color-card-content-muted));
 }

--- a/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.module.scss
@@ -4,10 +4,10 @@
   flex-shrink: 0;
   gap: 8px;
   margin-block: 18px;
-  color: rgb(var(--color-facet-selector-color));
-  background: rgb(var(--color-facet-selector-surface));
+  color: rgb(var(--color-select-content));
+  background: rgb(var(--color-select-surface));
   border-radius: var(--border-radius-extra-small);
-  box-shadow: 0 0 0 1px rgb(var(--color-facet-selector-border));
+  box-shadow: 0 0 0 1px rgb(var(--color-select-border));
 }
 
 .prefix {
@@ -20,13 +20,12 @@
   place-self: start;
   align-items: flex-start;
   font-weight: 500;
-  color: rgb(var(--color-facet-selector-prefix));
-  background: rgb(var(--color-facet-selector-surface));
-  box-shadow: 0 0 0 3px rgb(var(--color-facet-selector-surface));
+  color: rgb(var(--color-select-prefix));
+  background: rgb(var(--color-select-surface));
+  box-shadow: 0 0 0 3px rgb(var(--color-select-surface));
   transform: translate(16px, -50%);
 }
 
-.trigger,
 .label {
   @include type-body-medium;
 
@@ -37,53 +36,4 @@
   justify-content: space-between;
   width: 100%;
   padding: 12px 16px;
-}
-
-.trigger {
-  cursor: pointer;
-}
-
-.arrow {
-  flex-shrink: 0;
-  place-self: center end;
-  font-size: 14px;
-  line-height: 16.4px;
-}
-
-.dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: $z-index-above-content;
-  width: 100%;
-  min-width: 280px;
-  margin-top: 5px;
-  overflow: hidden;
-  background: rgb(var(--color-facet-selector-surface));
-  border-radius: var(--border-radius-extra-small);
-  box-shadow: var(--shadow-elevated);
-}
-
-.option {
-  @include type-body-medium;
-
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 100%;
-  padding: 12px 16px;
-  color: rgb(var(--color-facet-selector-color));
-  text-align: left;
-  cursor: pointer;
-  background: transparent;
-
-  &[data-is-selected="true"] {
-    background: rgb(var(--color-facet-selector-option-selected));
-  }
-
-  &:not([data-is-selected="true"]) {
-    @include hover {
-      background: rgb(var(--color-facet-selector-option-hover));
-    }
-  }
 }

--- a/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { Select } from '~/components/elements/select';
 import type { FacetInfo } from '~/server/types';
 import s from './facet_selector.module.scss';
 
@@ -21,7 +21,6 @@ export const FacetSelector = ({
   selectedFacetId,
   onSelect,
 }: FacetSelectorProps) => {
-  const [isOpen, setIsOpen] = useState(false);
   const currentFacet = facets.find((f) => f.facetId === selectedFacetId);
 
   if (!currentFacet || facets.length <= 1) {
@@ -34,39 +33,15 @@ export const FacetSelector = ({
   }
 
   return (
-    <div className={s.container}>
-      <span className={s.prefix}>Facet</span>
-      <button
-        type="button"
-        className={s.trigger}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        onPointerDown={(event) => event.stopPropagation()}
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        <span>{formatFacetLabel(currentFacet)}</span>
-        <span className={s.arrow}>▾</span>
-      </button>
-
-      {isOpen && (
-        <div className={s.dropdown}>
-          {facets.map((facet) => (
-            <button
-              key={facet.facetId}
-              type="button"
-              className={s.option}
-              data-is-selected={facet.facetId === selectedFacetId}
-              onPointerDown={(event) => event.stopPropagation()}
-              onClick={() => {
-                onSelect(facet.facetId);
-                setIsOpen(false);
-              }}
-            >
-              {formatFacetLabel(facet)}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+    <Select
+      className={s.container}
+      options={facets}
+      value={currentFacet}
+      onSelect={(facet) => onSelect(facet.facetId)}
+      getKey={(facet) => facet.facetId}
+      renderOption={formatFacetLabel}
+      label="Facet"
+      aria-label="Select data facet"
+    />
   );
 };

--- a/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.tsx
@@ -28,6 +28,7 @@ export const FacetSelector = ({
   if (!currentFacet || facets.length <= 1) {
     return currentFacet ? (
       <div className={clsx(s.label, s.container)}>
+        <span className={s.prefix}>Facet</span>
         {formatFacetLabel(currentFacet)}
       </div>
     ) : null;
@@ -35,7 +36,7 @@ export const FacetSelector = ({
 
   return (
     <div className={s.container}>
-      <span className={s.prefix}>Facet:</span>
+      <span className={s.prefix}>Facet</span>
       <button
         type="button"
         className={s.trigger}
@@ -62,13 +63,7 @@ export const FacetSelector = ({
                 setIsOpen(false);
               }}
             >
-              <span className={s['option-source']}>{facet.source}</span>
-              <span className={s['option-meta']}>
-                {facet.earliestDate}–{facet.latestDate},{' '}
-                {facet.unit.toLowerCase() === 'dimensionless'
-                  ? 'Dimensionless'
-                  : facet.unit}
-              </span>
+              {formatFacetLabel(facet)}
             </button>
           ))}
         </div>

--- a/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/facet_selector.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import clsx from 'clsx';
 import { useState } from 'react';
 import type { FacetInfo } from '~/server/types';
 import s from './facet_selector.module.scss';
@@ -27,9 +26,9 @@ export const FacetSelector = ({
 
   if (!currentFacet || facets.length <= 1) {
     return currentFacet ? (
-      <div className={clsx(s.label, s.container)}>
+      <div className={s.container}>
         <span className={s.prefix}>Facet</span>
-        {formatFacetLabel(currentFacet)}
+        <span className={s.label}>{formatFacetLabel(currentFacet)}</span>
       </div>
     ) : null;
   }

--- a/dataweaver/apps/web/src/components/elements/select.module.scss
+++ b/dataweaver/apps/web/src/components/elements/select.module.scss
@@ -1,0 +1,98 @@
+.container {
+  position: relative;
+  display: grid;
+  flex-shrink: 0;
+  gap: 8px;
+  color: rgb(var(--color-select-content));
+  background: rgb(var(--color-select-surface));
+  border-radius: var(--border-radius-extra-small);
+  box-shadow: 0 0 0 1px rgb(var(--color-select-border));
+
+  &[data-is-disabled="true"] {
+    pointer-events: none;
+    opacity: 0.6;
+  }
+}
+
+.label {
+  @include type-body-small;
+
+  display: flex;
+  flex-shrink: 0;
+  grid-area: 1 / 1;
+  gap: 0;
+  place-self: start;
+  align-items: flex-start;
+  font-weight: 500;
+  color: rgb(var(--color-select-prefix));
+  background: rgb(var(--color-select-surface));
+  box-shadow: 0 0 0 3px rgb(var(--color-select-surface));
+  transform: translate(16px, -50%);
+}
+
+.trigger {
+  @include type-body-medium;
+
+  display: flex;
+  grid-area: 1 / 1;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
+.trigger-content {
+  display: flex;
+  align-items: center;
+}
+
+.arrow {
+  flex-shrink: 0;
+  place-self: center end;
+  font-size: 14px;
+  line-height: 16.4px;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: $z-index-above-content;
+  width: 100%;
+  min-width: 280px;
+  margin-top: 5px;
+  overflow: hidden;
+  background: rgb(var(--color-select-surface));
+  border-radius: var(--border-radius-extra-small);
+  box-shadow: var(--shadow-elevated);
+}
+
+.option {
+  @include type-body-medium;
+
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 16px;
+  color: rgb(var(--color-select-content));
+  text-align: left;
+  cursor: pointer;
+  background: transparent;
+
+  &[data-is-selected="true"] {
+    background: rgb(var(--color-select-option-selected));
+  }
+
+  &:not([data-is-selected="true"]) {
+    @include hover {
+      background: rgb(var(--color-select-option-hover));
+    }
+  }
+}

--- a/dataweaver/apps/web/src/components/elements/select.tsx
+++ b/dataweaver/apps/web/src/components/elements/select.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { type ReactNode, useCallback, useRef, useState } from 'react';
+import { mergeClassNames } from '~/functions/merge_class_names';
+import { useClickOutside } from '~/hooks/use_click_outside';
+import { useKeydown } from '~/hooks/use_keydown';
+import s from './select.module.scss';
+
+interface SelectProps<T> {
+  options: T[];
+  value: T;
+  onSelect: (item: T) => void;
+  getKey: (item: T) => string;
+  renderOption: (item: T) => ReactNode;
+  renderTrigger?: (item: T) => ReactNode;
+
+  /** Optional floating prefix label (e.g. "Facet", "Sort by"). */
+  label?: string;
+
+  /** @default false */
+  isDisabled?: boolean;
+
+  'aria-label'?: string;
+  className?: string;
+}
+
+export const Select = <T,>({
+  options,
+  value,
+  onSelect,
+  getKey,
+  renderOption,
+  renderTrigger,
+  label,
+  isDisabled = false,
+  className,
+  ...rest
+}: SelectProps<T>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useClickOutside(containerRef, close, { isEnabled: isOpen });
+  useKeydown('Escape', close, { isEnabled: isOpen });
+
+  useKeydown(
+    ['ArrowDown', 'ArrowUp'],
+    (event) => {
+      event.preventDefault();
+      const focusedIndex = optionRefs.current.indexOf(
+        document.activeElement as HTMLButtonElement | null,
+      );
+      const direction = event.code === 'ArrowDown' ? 1 : -1;
+      const nextIndex =
+        (focusedIndex + direction + options.length) % options.length;
+      optionRefs.current[nextIndex]?.focus();
+    },
+    { isEnabled: isOpen },
+  );
+
+  const triggerContent = renderTrigger
+    ? renderTrigger(value)
+    : renderOption(value);
+
+  return (
+    <div
+      ref={containerRef}
+      className={mergeClassNames(s.container, className)}
+      data-is-disabled={isDisabled}
+    >
+      {label && <span className={s.label}>{label}</span>}
+
+      <button
+        type="button"
+        className={s.trigger}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-label={rest['aria-label']}
+        disabled={isDisabled}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span className={s['trigger-content']}>{triggerContent}</span>
+        <span className={s.arrow} aria-hidden="true">
+          ▾
+        </span>
+      </button>
+
+      {isOpen && (
+        <div
+          className={s.dropdown}
+          role="listbox"
+          aria-label={rest['aria-label']}
+        >
+          {options.map((option, index) => {
+            const key = getKey(option);
+            const isSelected = getKey(value) === key;
+            return (
+              <button
+                key={key}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
+                type="button"
+                className={s.option}
+                role="option"
+                aria-selected={isSelected}
+                data-is-selected={isSelected}
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={() => {
+                  onSelect(option);
+                  setIsOpen(false);
+                }}
+              >
+                {renderOption(option)}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/dataweaver/apps/web/src/styles/core/_root.scss
+++ b/dataweaver/apps/web/src/styles/core/_root.scss
@@ -23,6 +23,7 @@
     --border-radius-large: 28px;
     --border-radius-medium: 16px;
     --border-radius-small: 8px;
+    --border-radius-extra-small: 4px;
     --actions-height: calc(var(--button-circle-size-large) + 10px);
   }
 }

--- a/dataweaver/packages/tokens/src/colors.json
+++ b/dataweaver/packages/tokens/src/colors.json
@@ -104,12 +104,19 @@
   "card-action-content-hover": "$accent",
   "card-accent-subtle": "$accent-subtle",
 
-  "facet-selector-surface": "$card-surface",
-  "facet-selector-border": [196, 199, 197],
-  "facet-selector-color": "$card-content",
-  "facet-selector-prefix": "$content-muted",
-  "facet-selector-option-selected": "$accent-subtle",
-  "facet-selector-option-hover": "$accent-subtle-strong",
+  "select-surface": "$card-surface",
+  "select-border": [196, 199, 197],
+  "select-content": "$card-content",
+  "select-prefix": "$content-muted",
+  "select-option-selected": "$accent-subtle",
+  "select-option-hover": "$accent-subtle-strong",
+
+  "facet-selector-surface": "$select-surface",
+  "facet-selector-border": "$select-border",
+  "facet-selector-color": "$select-content",
+  "facet-selector-prefix": "$select-prefix",
+  "facet-selector-option-selected": "$select-option-selected",
+  "facet-selector-option-hover": "$select-option-hover",
 
   "skeleton-surface": [242, 242, 242],
 

--- a/dataweaver/packages/tokens/src/colors.json
+++ b/dataweaver/packages/tokens/src/colors.json
@@ -107,6 +107,9 @@
   "facet-selector-surface": "$card-surface",
   "facet-selector-border": [196, 199, 197],
   "facet-selector-color": "$card-content",
+  "facet-selector-prefix": "$content-muted",
+  "facet-selector-option-selected": "$accent-subtle",
+  "facet-selector-option-hover": "$accent-subtle-strong",
 
   "skeleton-surface": [242, 242, 242],
 

--- a/dataweaver/packages/tokens/src/colors.json
+++ b/dataweaver/packages/tokens/src/colors.json
@@ -104,6 +104,10 @@
   "card-action-content-hover": "$accent",
   "card-accent-subtle": "$accent-subtle",
 
+  "facet-selector-surface": "$card-surface",
+  "facet-selector-border": [196, 199, 197],
+  "facet-selector-color": "$card-content",
+
   "skeleton-surface": [242, 242, 242],
 
   "menu-surface": "$surface-dimmed",


### PR DESCRIPTION
## Overview

- Updates the styles for the facet selector in chart cards.
- adds tokens for facet selector colors

<img width="460" height="536" alt="Screenshot 2026-07-16 at 3 23 25 PM" src="https://github.com/user-attachments/assets/6774444b-f599-431e-939d-8bfcea6ca46b" />

<img width="465" height="544" alt="Screenshot 2026-07-16 at 3 23 19 PM" src="https://github.com/user-attachments/assets/795ce812-2525-4189-9f69-c3c4dceb8859" />