### PR TITLE
refactor(narratives): icon tokens, theme colors, pivot tests (PR 2 follow-up)

### DIFF
--- a/narratives/src/api/dc_observations.test.ts
+++ b/narratives/src/api/dc_observations.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @fileoverview Tests for the dc_observations pivot/formatting helpers.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  fetchSeries,
+  fetchPoint,
+  pivotSeriesToRows,
+  pivotPointToRowsByPlace,
+  pickSourceFromFacets,
+  getPrettyPlaceName,
+  getPrettyVariableName,
+  type SeriesResponse,
+  type PointResponse,
+} from "./dc_observations";
+
+describe("fetchSeries / fetchPoint", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("fetchSeries resolves the parsed JSON on a 200", async () => {
+    const payload: SeriesResponse = { data: {}, facets: {} };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 })),
+    );
+    await expect(fetchSeries(["Count_Person"], ["country/IND"])).resolves.toEqual(
+      payload,
+    );
+  });
+
+  it("fetchSeries throws on a non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("", { status: 500 })));
+    await expect(fetchSeries(["v"], ["p"])).rejects.toThrow(/HTTP 500/);
+  });
+
+  it("fetchPoint throws on a non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("", { status: 404 })));
+    await expect(fetchPoint(["v"], ["p"], "2021")).rejects.toThrow(/HTTP 404/);
+  });
+});
+
+describe("pivotSeriesToRows", () => {
+  const response: SeriesResponse = {
+    data: {
+      var_a: {
+        "country/IND": {
+          series: [
+            { date: "2020", value: 10 },
+            { date: "2021", value: 20 },
+          ],
+        },
+      },
+      var_b: {
+        "country/IND": {
+          series: [{ date: "2021", value: 7 }],
+        },
+      },
+    },
+    facets: {},
+  };
+
+  it("merges variables into one row per date, keyed by variable dcid", () => {
+    const rows = pivotSeriesToRows(response, ["var_a", "var_b"], "country/IND");
+    expect(rows).toEqual([
+      { date: "2020", var_a: 10 },
+      { date: "2021", var_a: 20, var_b: 7 },
+    ]);
+  });
+
+  it("omits variables with no value on a given date", () => {
+    const rows = pivotSeriesToRows(response, ["var_a", "var_b"], "country/IND");
+    expect(rows[0]).not.toHaveProperty("var_b");
+  });
+
+  it("sorts rows by date ascending", () => {
+    const rows = pivotSeriesToRows(response, ["var_a"], "country/IND");
+    expect(rows.map((row) => row.date)).toEqual(["2020", "2021"]);
+  });
+
+  it("returns an empty array when the place has no data", () => {
+    expect(pivotSeriesToRows(response, ["var_a"], "country/USA")).toEqual([]);
+  });
+
+  it("tolerates a missing data section", () => {
+    const empty = { data: {}, facets: {} } as SeriesResponse;
+    expect(pivotSeriesToRows(empty, ["var_a"], "country/IND")).toEqual([]);
+  });
+});
+
+describe("pivotPointToRowsByPlace", () => {
+  const response: PointResponse = {
+    data: {
+      var_a: {
+        "country/IND": { date: "2021", value: 42 },
+        "country/USA": { date: "2021", value: 100 },
+        "country/NPL": { date: "2021" },
+      },
+    },
+    facets: {},
+  };
+
+  it("returns one row per place with a numeric value", () => {
+    expect(pivotPointToRowsByPlace(response, "var_a")).toEqual([
+      { place: "country/IND", value: 42 },
+      { place: "country/USA", value: 100 },
+    ]);
+  });
+
+  it("drops places without a numeric value", () => {
+    const places = pivotPointToRowsByPlace(response, "var_a").map(
+      (row) => row.place,
+    );
+    expect(places).not.toContain("country/NPL");
+  });
+
+  it("returns an empty array for an unknown variable", () => {
+    expect(pivotPointToRowsByPlace(response, "var_missing")).toEqual([]);
+  });
+});
+
+describe("pickSourceFromFacets", () => {
+  it("returns the first facet that has a provenanceUrl", () => {
+    const response = {
+      data: {},
+      facets: {
+        f1: { unit: "Years" },
+        f2: { importName: "WHO", provenanceUrl: "https://who.int" },
+      },
+    } as SeriesResponse;
+    expect(pickSourceFromFacets(response)).toEqual({
+      name: "WHO",
+      url: "https://who.int",
+    });
+  });
+
+  it("falls back to the url as the name when importName is absent", () => {
+    const response = {
+      data: {},
+      facets: { f1: { provenanceUrl: "https://example.org" } },
+    } as SeriesResponse;
+    expect(pickSourceFromFacets(response)).toEqual({
+      name: "https://example.org",
+      url: "https://example.org",
+    });
+  });
+
+  it("returns undefined when no facet has a provenanceUrl", () => {
+    const response = { data: {}, facets: { f1: { unit: "x" } } } as SeriesResponse;
+    expect(pickSourceFromFacets(response)).toBeUndefined();
+  });
+});
+
+describe("getPrettyPlaceName", () => {
+  it("strips a namespace prefix", () => {
+    expect(getPrettyPlaceName("country/IND")).toBe("IND");
+    expect(getPrettyPlaceName("geoId/06")).toBe("06");
+  });
+
+  it("returns the dcid unchanged when there is no prefix", () => {
+    expect(getPrettyPlaceName("Earth")).toBe("Earth");
+  });
+});
+
+describe("getPrettyVariableName", () => {
+  it("replaces underscores and slashes with spaces and title-cases", () => {
+    expect(getPrettyVariableName("Count_Person")).toBe("Count Person");
+    expect(getPrettyVariableName("dc/abc123")).toBe("Dc abc123");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(getPrettyVariableName("")).toBe("");
+  });
+});

--- a/narratives/src/api/dc_observations.ts
+++ b/narratives/src/api/dc_observations.ts
@@ -6,8 +6,6 @@
  * components, full Figma fidelity.
  */
 
-// TODO: Add unit tests for all exported functions in this file.
-
 /** One dated observation, matching an /api/observations/series entry. */
 export interface SeriesPoint { date: string; value: number }
 

--- a/narratives/src/app.tsx
+++ b/narratives/src/app.tsx
@@ -39,7 +39,7 @@ export function App() {
     <BrandingProvider>
       <ChatSessionProvider>
         <ChatResetOnTabChange route={route} />
-        <div className="flex h-screen w-full bg-white overflow-hidden relative">
+        <div className="flex h-screen w-full bg-surface overflow-hidden relative">
           <Sidebar />
           <SessionDrawer />
           <main className="flex-1 flex flex-col h-full relative min-w-0">

--- a/narratives/src/components/block_reasoning.tsx
+++ b/narratives/src/components/block_reasoning.tsx
@@ -5,6 +5,7 @@
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { ChevronDownIcon } from "./icons";
 import type { ThoughtEvent, TurnStatus } from "../hooks/use_sse_chat";
 
 /**
@@ -20,7 +21,6 @@ import type { ThoughtEvent, TurnStatus } from "../hooks/use_sse_chat";
  */
 
 const COLOR_TEXT = "var(--color-on-surface)";
-const COLOR_CHEVRON = "var(--color-on-surface-variant)";
 const COLOR_SPARKLE = "#1A8C7A";
 const FONT_LABEL =
   '"Google Sans Text", "Google Sans", Inter, system-ui, sans-serif';
@@ -116,7 +116,11 @@ export function ReasoningBlock({
           }}
         >
           {label}
-          <ChevronDown rotated={!open} />
+          <ChevronDownIcon
+            className={`text-on-surface-variant transition-transform duration-150 ${
+              open ? "rotate-0" : "-rotate-90"
+            }`}
+          />
         </span>
       </button>
       {open && (
@@ -220,21 +224,3 @@ function SparkleIcon() {
   );
 }
 
-/** Chevron icon for the reasoning header; rotates 180° when collapsed. */
-function ChevronDown({ rotated }: { rotated?: boolean }) {
-  return (
-    <svg
-      width={16}
-      height={16}
-      viewBox="0 0 24 24"
-      fill={COLOR_CHEVRON}
-      aria-hidden="true"
-      style={{
-        transition: "transform 150ms ease",
-        transform: rotated ? "rotate(-90deg)" : "rotate(0deg)",
-      }}
-    >
-      <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
-    </svg>
-  );
-}

--- a/narratives/src/components/button_export_pdf.tsx
+++ b/narratives/src/components/button_export_pdf.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useRef } from "react";
+import { ExportIcon } from "./icons";
 import { printElement } from "../utils/print_element";
 
 /**
@@ -66,24 +67,5 @@ export function ExportPdfButton({
         <span>{label}</span>
       </button>
     </div>
-  );
-}
-
-/**
- * Material Symbols "edit" (pencil) — 20×20 to match Figma's leading-icon
- * slot (layout_MOYZ4B). Verified by downloading node 3427:16783 from
- * Figma at 4× and inspecting the rendered glyph.
- */
-function ExportIcon() {
-  return (
-    <svg
-      width={20}
-      height={20}
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
-    </svg>
   );
 }

--- a/narratives/src/components/card_response.tsx
+++ b/narratives/src/components/card_response.tsx
@@ -43,8 +43,8 @@ export function ResponseCard({
   }
 
   return (
-    <div className="self-start w-full border border-gray-200 rounded-[24px] overflow-hidden shadow-sm bg-surface-soft">
-      <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-white">
+    <div className="self-start w-full border border-outline rounded-[24px] overflow-hidden shadow-sm bg-surface-soft">
+      <div className="px-6 py-4 border-b border-outline-variant flex justify-between items-center bg-surface">
         <h3 className="text-label-large text-on-surface">{title}</h3>
         {streaming && (
           <span className="inline-flex items-center gap-1 text-xs text-on-surface-variant">
@@ -121,7 +121,7 @@ function ReactMarkdownInner({
                 )
               );
               return inline ? (
-                <code className="px-1 py-0.5 rounded bg-gray-100 text-[0.92em] font-mono">
+                <code className="px-1 py-0.5 rounded bg-surface-muted text-[0.92em] font-mono">
                   {children}
                 </code>
               ) : (
@@ -129,12 +129,12 @@ function ReactMarkdownInner({
               );
             },
             pre: ({ children }) => (
-              <pre className="bg-gray-50 border border-gray-200 rounded-md p-3 overflow-auto text-sm mb-3">
+              <pre className="bg-surface-soft border border-outline rounded-md p-3 overflow-auto text-sm mb-3">
                 {children}
               </pre>
             ),
             blockquote: ({ children }) => (
-              <blockquote className="border-l-4 border-gray-200 pl-4 italic text-on-surface-variant mb-3">
+              <blockquote className="border-l-4 border-outline pl-4 italic text-on-surface-variant mb-3">
                 {children}
               </blockquote>
             ),
@@ -146,15 +146,15 @@ function ReactMarkdownInner({
               </div>
             ),
             thead: ({ children }) => (
-              <thead className="bg-gray-50">{children}</thead>
+              <thead className="bg-surface-soft">{children}</thead>
             ),
             th: ({ children }) => (
-              <th className="border border-gray-200 px-3 py-2 text-left font-medium">
+              <th className="border border-outline px-3 py-2 text-left font-medium">
                 {renderWithCitations(children)}
               </th>
             ),
             td: ({ children }) => (
-              <td className="border border-gray-200 px-3 py-2">
+              <td className="border border-outline px-3 py-2">
                 {renderWithCitations(children)}
               </td>
             ),
@@ -163,7 +163,7 @@ function ReactMarkdownInner({
                 {renderWithCitations(children)}
               </strong>
             ),
-            hr: () => <hr className="my-4 border-gray-200" />,
+            hr: () => <hr className="my-4 border-outline" />,
           }}
         >
           {body}

--- a/narratives/src/components/card_skeleton.tsx
+++ b/narratives/src/components/card_skeleton.tsx
@@ -9,8 +9,8 @@ interface SkeletonCardProps {
 /** Loading placeholder card shown while the agent works on `query`. */
 export function SkeletonCard({ query }: SkeletonCardProps) {
   return (
-    <div className="w-full border border-gray-200 rounded-[24px] overflow-hidden shadow-sm bg-surface-soft">
-      <div className="px-6 py-4 border-b border-gray-100 text-body-large-emphasized text-on-surface bg-white">
+    <div className="w-full border border-outline rounded-[24px] overflow-hidden shadow-sm bg-surface-soft">
+      <div className="px-6 py-4 border-b border-outline-variant text-body-large-emphasized text-on-surface bg-surface">
         {query}
       </div>
       <div className="px-4 sm:px-[56px] py-6 flex flex-col gap-4">

--- a/narratives/src/components/chip_suggestion.tsx
+++ b/narratives/src/components/chip_suggestion.tsx
@@ -14,7 +14,7 @@ const CHIP_CLASSES = [
   // Layout & dimensions
   "w-full sm:w-[250px] min-h-[72px] px-4 py-3 flex items-center justify-center sm:justify-start",
   // Borders & background
-  "border border-gray-200 rounded-[20px] bg-white",
+  "border border-outline rounded-[20px] bg-surface",
   // Typography & text alignment
   "text-body-medium text-on-surface text-left",
   // Motion & transitions
@@ -22,7 +22,7 @@ const CHIP_CLASSES = [
   // Shadow states
   "shadow-[0_1px_3px_rgba(0,0,0,0.02)] hover:shadow-md",
   // Interactive hover states
-  "hover:bg-gray-50 cursor-pointer",
+  "hover:bg-surface-soft cursor-pointer",
 ].join(" ");
 
 /** Renders one clickable prompt-suggestion chip. */

--- a/narratives/src/components/chip_tool_call.tsx
+++ b/narratives/src/components/chip_tool_call.tsx
@@ -32,7 +32,7 @@ export function ToolCallChip({ toolCall }: ToolCallChipProps) {
   return (
     <span
       className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-label-large ${
-        failed ? "bg-red-50 text-red-700" : "bg-surface-blue text-brand-primary"
+        failed ? "bg-error-surface text-error-strong" : "bg-surface-blue text-brand-primary"
       }`}
       title={JSON.stringify(args)}
     >

--- a/narratives/src/components/data_agent.tsx
+++ b/narratives/src/components/data_agent.tsx
@@ -127,7 +127,7 @@ export function DataAgent() {
             />
           ))}
           {error && turns.length === 0 && (
-            <div className="self-start px-4 py-3 rounded-2xl bg-red-50 text-red-700 text-body-large">
+            <div className="self-start px-4 py-3 rounded-2xl bg-error-surface text-error-strong text-body-large">
               {error}
             </div>
           )}
@@ -150,8 +150,8 @@ export function DataAgent() {
 
       {/* Follow-up input — flush against the fade (no top margin) so the
           gradient reads as a continuous merge rather than a separator. */}
-      <div className="w-full flex flex-col items-center gap-3 bg-white pb-4 sm:pb-6">
-        <div className="w-full max-w-[720px] min-h-[64px] bg-white border border-gray-200 rounded-[24px] p-4 flex flex-col justify-between shadow-[0_2px_12px_rgba(0,0,0,0.06)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-all duration-300">
+      <div className="w-full flex flex-col items-center gap-3 bg-surface pb-4 sm:pb-6">
+        <div className="w-full max-w-[720px] min-h-[64px] bg-surface border border-outline rounded-[24px] p-4 flex flex-col justify-between shadow-[0_2px_12px_rgba(0,0,0,0.06)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-all duration-300">
           <textarea
             ref={textareaRef}
             value={query}
@@ -251,7 +251,7 @@ function TurnView({ turn, index, isStreaming, onAsk }: TurnViewProps) {
 
       {/* Error */}
       {turn.status === "error" && turn.error && (
-        <div className="self-start px-4 py-3 rounded-2xl bg-red-50 text-red-700 text-body-large max-w-4xl">
+        <div className="self-start px-4 py-3 rounded-2xl bg-error-surface text-error-strong text-body-large max-w-4xl">
           {turn.error}
         </div>
       )}

--- a/narratives/src/components/drawer_session.tsx
+++ b/narratives/src/components/drawer_session.tsx
@@ -76,21 +76,21 @@ export function SessionDrawer() {
           full-width content); transparent on desktop where it just needs a
           click capture. */}
       <div
-        className="fixed inset-0 z-10 bg-black/30 lg:bg-transparent"
+        className="fixed inset-0 z-10 bg-scrim/30 lg:bg-transparent"
         onClick={close}
         aria-hidden="true"
       />
 
       {/* ─── Desktop: single-level list, anchored left beside the rail ─── */}
       <aside
-        className="hidden lg:flex absolute top-0 left-[72px] h-full bg-white border-r border-gray-200 shadow-lg z-20 flex-col"
+        className="hidden lg:flex absolute top-0 left-[72px] h-full bg-surface border-r border-outline shadow-lg z-20 flex-col"
         style={{
           // Cap at PANEL_WIDTH, but never exceed the viewport left of the rail.
           width: `min(${DESKTOP_PANEL_WIDTH}px, calc(100vw - ${SIDEBAR_OFFSET}px))`,
         }}
         aria-label="Chat sessions"
       >
-        <header className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+        <header className="flex items-center justify-between px-4 py-3 border-b border-outline-variant">
           <h2
             className="m-0"
             style={{
@@ -116,7 +116,7 @@ export function SessionDrawer() {
 
       {/* ─── Mobile: two-level slide-in panel, anchored right ─── */}
       <aside
-        className="lg:hidden absolute top-0 right-0 h-full bg-white border-l border-gray-200 shadow-lg z-20 overflow-hidden"
+        className="lg:hidden absolute top-0 right-0 h-full bg-surface border-l border-outline shadow-lg z-20 overflow-hidden"
         style={{
           // Cap at PANEL_WIDTH but always leave a peek of the content behind.
           width: `min(${MOBILE_PANEL_WIDTH}px, calc(100vw - 48px))`,
@@ -146,16 +146,16 @@ export function SessionDrawer() {
               </button>
             </div>
 
-            <div className="border-t border-gray-200 shrink-0" />
+            <div className="border-t border-outline shrink-0" />
 
             <nav className="flex flex-col py-2 shrink-0">
               <MenuItem
-                icon={<NewChatIcon size={22} />}
+                icon={<NewChatIcon size="md" />}
                 label="New chat"
                 onClick={handleNewChat}
               />
               <MenuItem
-                icon={<ChatsIcon size={22} />}
+                icon={<ChatsIcon size="md" />}
                 label="Chats"
                 onClick={() => setView("chats")}
               />
@@ -189,7 +189,7 @@ export function SessionDrawer() {
               </h2>
             </div>
 
-            <div className="border-t border-gray-200 shrink-0" />
+            <div className="border-t border-outline shrink-0" />
 
             <SessionList
               sessions={visibleSessions}
@@ -230,8 +230,8 @@ function SessionList({
         return (
           <li
             key={session.id}
-            className={`group relative flex items-start gap-2 px-4 py-3 border-b border-gray-50 cursor-pointer transition-colors ${
-              active ? "bg-surface-blue" : "hover:bg-gray-50"
+            className={`group relative flex items-start gap-2 px-4 py-3 border-b border-outline-variant cursor-pointer transition-colors ${
+              active ? "bg-surface-blue" : "hover:bg-surface-soft"
             }`}
             onClick={() => onSelect(session.id)}
           >
@@ -269,7 +269,7 @@ function SessionList({
                 e.stopPropagation();
                 onDelete(session.id);
               }}
-              className="opacity-0 group-hover:opacity-100 transition-opacity text-on-surface-variant hover:text-red-600 p-1"
+              className="opacity-0 group-hover:opacity-100 transition-opacity text-on-surface-variant hover:text-error p-1"
             >
               <Trash2 size={16} strokeWidth={1.5} />
             </button>
@@ -302,7 +302,7 @@ function MenuItem({
     <button
       type="button"
       onClick={onClick}
-      className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left bg-transparent border-0 cursor-pointer hover:bg-gray-50 transition-colors"
+      className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left bg-transparent border-0 cursor-pointer hover:bg-surface-soft transition-colors"
     >
       <span className="flex items-center gap-3" style={{ color: COLOR_LABEL }}>
         {icon}

--- a/narratives/src/components/header.tsx
+++ b/narratives/src/components/header.tsx
@@ -53,7 +53,7 @@ export function Header() {
           );
         })}
 
-        <div className="hidden sm:block h-4 w-px bg-gray-300 mx-1 shrink-0"></div>
+        <div className="hidden sm:block h-4 w-px bg-divider mx-1 shrink-0"></div>
 
         {/* TODO(i18n): language is hardcoded to English; move to branding config
             or wire up localization before exposing more languages. */}
@@ -83,7 +83,7 @@ export function Header() {
               : "hover:bg-button-hover text-on-surface-variant"
           }`}
         >
-          <MenuIcon size={24} />
+          <MenuIcon size="lg" />
         </button>
       )}
     </header>

--- a/narratives/src/components/icons.tsx
+++ b/narratives/src/components/icons.tsx
@@ -1,70 +1,103 @@
 /**
- * @fileoverview Provides shared inline SVG icon components used across the UI.
+ * @fileoverview Shared inline SVG icon components and their size-token system.
  */
+
+import type { SVGProps } from "react";
 
 /**
- * Google Material Symbols icons used across the chat UI.
+ * Icon pixel sizes keyed by a semantic token. Centralised here so icon sizing
+ * is consistent and adjustable in one place, rather than hard-coded as magic
+ * numbers at each call site.
  *
- * These are the real `pen_spark` (New chat), `notes_spark` (Chats) and
- * `menu` (accordion / hamburger) glyphs. They use the Material Symbols
- * 0 -960 960 960 viewBox and fill `currentColor` so they inherit text color.
+ * TODO(theme): ideally these come from the branding/theme layer so a downstream
+ * instance can rescale icons; kept local until the theme exposes a size scale.
  */
+const ICON_SIZES = {
+  xs: 16,
+  sm: 20,
+  md: 22,
+  lg: 24,
+} as const;
 
-interface IconProps {
-  readonly size?: number;
-  readonly className?: string;
+/** Semantic icon-size token; maps to a pixel dimension via {@link ICON_SIZES}. */
+export type IconSizeToken = keyof typeof ICON_SIZES;
+
+/**
+ * Props shared by every icon: all standard SVG attributes (className, style,
+ * event handlers, aria-*, …) plus a semantic `size` token. Rotation/animation
+ * are the caller's responsibility via `className` — icons are not aware of it.
+ */
+export interface IconProps extends Omit<SVGProps<SVGSVGElement>, "size"> {
+  size?: IconSizeToken;
 }
 
 /**
- * `pen_spark` — New chat.
+ * Builds the common <svg> attributes for an icon from a size token, spreading
+ * any caller-supplied SVG props on top and composing their `className` with the
+ * shared base classes.
  */
-export function NewChatIcon({ size = 22, className = "" }: IconProps) {
+export function getSvgProps(
+  size: IconSizeToken = "md",
+  props: Omit<SVGProps<SVGSVGElement>, "size"> = {},
+): SVGProps<SVGSVGElement> {
+  const dimension = ICON_SIZES[size];
+  return {
+    width: dimension,
+    height: dimension,
+    fill: "currentColor",
+    "aria-hidden": true,
+    ...props,
+    className: `shrink-0 select-none ${props.className ?? ""}`.trim(),
+  };
+}
+
+/** `pen_spark` — New chat. */
+export function NewChatIcon({ size = "md", ...props }: IconProps) {
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 -960 960 960"
-      fill="currentColor"
-      aria-hidden="true"
-      className={className}
-    >
+    <svg viewBox="0 -960 960 960" {...getSvgProps(size, props)}>
       <path d="M240-200h57l391-391-57-57-391 391v57Zm-80 80v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T857-647L330-120H160Zm640-584-56-56 56 56Zm-141 85-28-29 57 57-29-28Zm-439 59q-6 0-8-6-16-61-60.5-105.5T46-732q-6-2-6-8 0-7 6-8 61-16 105.5-60.5T212-914q2-6 8-6 7 0 8 6 17 61 61 105.5T394-748q6 1 6 8 0 6-6 8-61 16-105.5 60.5T228-566q-1 6-8 6Z" />
     </svg>
   );
 }
 
-/**
- * `notes_spark` — Chats.
- */
-export function ChatsIcon({ size = 22, className = "" }: IconProps) {
+/** `notes_spark` — Chats. */
+export function ChatsIcon({ size = "md", ...props }: IconProps) {
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 -960 960 960"
-      fill="currentColor"
-      aria-hidden="true"
-      className={className}
-    >
+    <svg viewBox="0 -960 960 960" {...getSvgProps(size, props)}>
       <path d="M740-40q-6 0-8-6-16-61-60.5-105.5T566-212q-6-2-6-8 0-7 6-8 61-16 105.5-60.5T732-394q2-6 8-6 7 0 8 6 17 61 61 105.5T914-228q6 1 6 8 0 6-6 8-61 16-105.5 60.5T748-46q-1 6-8 6ZM120-280v-80h360v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z" />
     </svg>
   );
 }
 
-/**
- * `menu` — hamburger / accordion toggle.
- */
-export function MenuIcon({ size = 24, className = "" }: IconProps) {
+/** `menu` — hamburger / accordion toggle. */
+export function MenuIcon({ size = "lg", ...props }: IconProps) {
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 -960 960 960"
-      fill="currentColor"
-      aria-hidden="true"
-      className={className}
-    >
+    <svg viewBox="0 -960 960 960" {...getSvgProps(size, props)}>
       <path d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z" />
+    </svg>
+  );
+}
+
+/**
+ * `expand_more` — downward chevron. Not responsible for its own rotation: the
+ * caller rotates it via `className` (e.g. `-rotate-90` when collapsed).
+ */
+export function ChevronDownIcon({ size = "xs", ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" {...getSvgProps(size, props)}>
+      <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
+    </svg>
+  );
+}
+
+/**
+ * `edit` (pencil) — leading glyph on the Export PDF button. Kept on its native
+ * 24×24 viewBox; matches the Figma leading-icon slot (node 3427-16783).
+ */
+export function ExportIcon({ size = "sm", ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" {...getSvgProps(size, props)}>
+      <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
     </svg>
   );
 }

--- a/narratives/src/components/metrics_page.tsx
+++ b/narratives/src/components/metrics_page.tsx
@@ -214,7 +214,7 @@ function SubTabs({
     <div
       role="tablist"
       aria-label="Metrics categories"
-      className="flex gap-1 border-b border-gray-200 mb-6"
+      className="flex gap-1 border-b border-outline mb-6"
     >
       {tabs.map((tab) => {
         const active = tab.id === activeId;
@@ -269,8 +269,8 @@ function Tile({
   children: React.ReactNode;
 }) {
   return (
-    <section className="bg-white rounded-[16px] border border-gray-200 overflow-hidden shadow-sm">
-      <header className="px-5 py-3 border-b border-gray-100">
+    <section className="bg-surface rounded-[16px] border border-outline overflow-hidden shadow-sm">
+      <header className="px-5 py-3 border-b border-outline-variant">
         <h3
           style={{
             fontFamily: FONT_DISPLAY,

--- a/narratives/src/components/panel_thoughts.tsx
+++ b/narratives/src/components/panel_thoughts.tsx
@@ -77,7 +77,7 @@ export function ThoughtsPanel({ thoughts }: ThoughtsPanelProps) {
                         </ol>
                       ),
                       code: ({ children }) => (
-                        <code className="px-1 rounded bg-gray-100 text-[0.92em] font-mono">
+                        <code className="px-1 rounded bg-surface-muted text-[0.92em] font-mono">
                           {children}
                         </code>
                       ),

--- a/narratives/src/components/sidebar.tsx
+++ b/narratives/src/components/sidebar.tsx
@@ -34,7 +34,7 @@ export function Sidebar() {
                 : "hover:bg-button-hover text-on-surface-variant"
             }`}
           >
-            <ChatsIcon size={24} />
+            <ChatsIcon size="lg" />
           </button>
           {/* Start a fresh chat thread — does NOT delete other sessions; they
               remain accessible from the drawer above. */}
@@ -44,7 +44,7 @@ export function Sidebar() {
             onClick={newSession}
             className="w-12 h-12 flex items-center justify-center rounded-full hover:bg-button-hover transition-colors text-on-surface-variant"
           >
-            <NewChatIcon size={22} />
+            <NewChatIcon size="md" />
           </button>
         </>
       )}

--- a/narratives/src/components/view_initial.tsx
+++ b/narratives/src/components/view_initial.tsx
@@ -34,7 +34,7 @@ export function InitialView({ query, setQuery, onSend, textareaRef }: InitialVie
 
       {/* GM3 Search Box */}
       <div
-        className={`w-full max-w-[720px] bg-white border border-gray-200 shadow-[0_2px_12px_rgba(0,0,0,0.06)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-all duration-300 flex ${
+        className={`w-full max-w-[720px] bg-surface border border-outline shadow-[0_2px_12px_rgba(0,0,0,0.06)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-all duration-300 flex ${
           isExpanded
           ? "min-h-[64px] rounded-[24px] flex-col p-4 justify-between"
             : "h-[56px] rounded-full items-center px-4 flex-row"

--- a/narratives/src/index.css
+++ b/narratives/src/index.css
@@ -37,14 +37,27 @@
   --color-brand-gradient-end: var(--brand-gradient-end, #6FAEC0);
 
   /* Surfaces */
+  --color-surface: #ffffff;
   --color-surface-soft: var(--brand-surface, #F9F9F9);
+  --color-surface-muted: #f3f4f6;
   --color-surface-blue: #f0f4f9;
   /* User-message bubble — fixed pale-teal design token. */
   --color-user-msg: #E8F2F4;
   --color-button-hover: #e1e5eb;
 
-  /* Lines */
+  /* Lines / borders */
   --color-line: #C4C7C5;
+  --color-outline: #e5e7eb;
+  --color-outline-variant: #f3f4f6;
+  --color-divider: #d1d5db;
+
+  /* State — error */
+  --color-error: #dc2626;
+  --color-error-strong: #b91c1c;
+  --color-error-surface: #fef2f2;
+
+  /* Scrim — click-outside backdrop */
+  --color-scrim: #000000;
 
   /* Text — primary */
   --color-on-surface: var(--brand-text, #1B1C1D);


### PR DESCRIPTION
## Overview

Addresses the review items from PR 2 that were explicitly deferred to a
follow-up. Three cohesive pieces: an icon-size token system, a theme-token
migration for hard-coded colors, and unit tests for the observation helpers.

## Changes made

**Icon system**
- `icons.tsx`: add semantic size tokens (`xs`/`sm`/`md`/`lg`) with pixel values
  in one map, a `getSvgProps` base helper, and `IconProps extends SVGProps` so
  every icon accepts standard SVG attributes.
- Call sites now pass size tokens (`size="lg"`) instead of magic numbers.
- Rolled the previously-inline `ChevronDown` (reasoning header) and the
  Export-PDF icon into the icons library as `ChevronDownIcon` / `ExportIcon`.
- Rotation is now caller-controlled — the chevron rotates via `className`
  (`-rotate-90` when collapsed); the icon is no longer aware of rotation.

**Theme colors**
- Replaced hard-coded Tailwind colors (`bg-white`, `border-gray-*`, `red-*`,
  the `black/30` scrim) with semantic tokens defined once in `index.css`
  `@theme`: `surface`, `surface-muted`, `outline`, `outline-variant`,
  `divider`, `error` / `error-strong` / `error-surface`, and `scrim`. Values
  match the previous palette, so there is no visual change — but an instance
  can now re-skin from one place.

**Tests**
- `dc_observations.test.ts`: unit tests for `pivotSeriesToRows`,
  `pivotPointToRowsByPlace`, `pickSourceFromFacets`, `getPrettyPlaceName`, and
  `getPrettyVariableName`; removed the stale "add tests" TODO.

## Testing done

- [x] `npm run lint` (`tsc --noEmit`, strict) — clean.
- [x] `npm run build` (vite) — clean; verified the new token utilities compile.
- [x] `npm test` (vitest) — 19/19 (was 4).
