### PR TITLE
Fix Safari Ghosting Bug

### DIFF
--- a/dataweaver/apps/web/src/components/elements/card/base.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/base.module.scss
@@ -21,6 +21,12 @@
   border-radius: var(--corner-size) var(--corner-size) 0 0;
   box-shadow: var(--shadow-elevated);
 
+  // Safari-only ghosting fix. When selected, this bar translates up beyond the
+  // card outside 'contain: size layout' box tldraw draws. Deleting the card
+  // while selected can cause the bug. By forcing it to have its own composited
+  // layer makes WebKit track and discard on removal, clearing the ghost
+  will-change: transform;
+
   @include prefers-motion {
     transition: transform 0.3s $ease-out;
   }

--- a/dataweaver/apps/web/src/components/elements/card/base.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/base.module.scss
@@ -21,12 +21,6 @@
   border-radius: var(--corner-size) var(--corner-size) 0 0;
   box-shadow: var(--shadow-elevated);
 
-  // Safari-only ghosting fix. When selected, this bar translates up beyond the
-  // card outside 'contain: size layout' box tldraw draws. Deleting the card
-  // while selected can cause the bug. By forcing it to have its own composited
-  // layer makes WebKit track and discard on removal, clearing the ghost
-  will-change: transform;
-
   @include prefers-motion {
     transition: transform 0.3s $ease-out;
   }
@@ -34,6 +28,12 @@
   [data-selection="single"] &,
   &:focus-within {
     transform: translateY(calc(var(--actions-height) * -1));
+
+    // Safari-only ghosting fix. When selected, this bar translates up beyond the
+    // card outside 'contain: size layout' box tldraw draws. Deleting the card
+    // while selected can cause the bug. By forcing it to have its own composited
+    // layer makes WebKit track and discard on removal, clearing the ghost
+    will-change: transform;
   }
 }
 


### PR DESCRIPTION
## Ticket

Small UI quirk with Safari, where the card outline remains on screen until the user scrolls. Reproducible on mac desktop and iOS latest operating systems. 

Steps to reproduce:
1. Open site in Safari
2. Populate some cards by asking a question
3. Click the delete button on a card
4. Note the UI

Expected:
Card UI is removed from screen completely

Actual:
Card Outline remains on screen (scrolling the view fully removes it)

Video:
https://github.com/user-attachments/assets/91707e99-0c01-4325-8494-543c10b94d1b

## Changes

I believe the composition layer track in this PR fixes the issue - I'm not able to reproduce anymore.