### PR TITLE
feat(narratives): stopped-turn UX, reasoning polish, token-usage readout

### DIFF
--- a/narratives/src/components/block_reasoning.tsx
+++ b/narratives/src/components/block_reasoning.tsx
@@ -152,11 +152,10 @@ export function ReasoningBlock({
   const [open, setOpen] = useState(defaultOpen);
   const label = phaseLabel(streaming, status);
 
-  // Flatten to a single markdown string (newline-separated). Phase grouping
-  // existed in the old ThoughtsPanel; the new Figma design renders the
-  // reasoning as one continuous block. When the agent emits no thoughts,
-  // we render a short status placeholder so the section stays present
-  // above the response card per Figma 3427-16715.
+  // Flatten to a single markdown string (newline-separated): the reasoning
+  // renders as one continuous block, not grouped per phase. When the agent
+  // emits no thoughts, we render a short status placeholder so the section
+  // stays present above the response card per Figma 3427-16715.
   const joined =
     thoughts.length > 0
       ? thoughts.map((thought) => thought.text).join("\n\n")

--- a/narratives/src/components/block_reasoning.tsx
+++ b/narratives/src/components/block_reasoning.tsx
@@ -2,7 +2,7 @@
  * @fileoverview Renders the agent's collapsible reasoning/thoughts block for a turn.
  */
 
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChevronDownIcon } from "./icons";
@@ -21,9 +21,83 @@ import type { ThoughtEvent, TurnStatus } from "../hooks/use_sse_chat";
  */
 
 const COLOR_TEXT = "var(--color-on-surface)";
+/** Reasoning body reads as a muted aside — one step softer than the response. */
+const COLOR_REASONING = "var(--color-on-surface-variant)";
 const COLOR_SPARKLE = "#1A8C7A";
 const FONT_LABEL =
   '"Google Sans Text", "Google Sans", Inter, system-ui, sans-serif';
+
+// The reasoning aside's left bar. The bar lives on the content blocks — both
+// headings and body (paragraphs, lists) — so each heading + its following body
+// share one continuous bar. Consecutive blocks have no vertical margin so their
+// borders touch; a heading's top margin opens a gap with no border, which is
+// what breaks the bar before the *next* heading.
+const BAR_WIDTH = 2;
+const BAR_PAD = 16;
+const BAR_INSET = BAR_WIDTH + BAR_PAD; // left offset of body text (border + pad)
+const BAR_COLOR = "var(--color-border, #E3E3E3)";
+// The reasoning icon (sparkle/loader) is ICON_SIZE wide and starts at the
+// aside's left edge, so its horizontal centre is at ICON_SIZE / 2. Shift the
+// content right so the bar is centred under that icon centre.
+const ICON_SIZE = 20;
+const BAR_CENTER_LEFT = ICON_SIZE / 2 - BAR_WIDTH / 2;
+
+/**
+ * Body blocks: the barred, italic detail text. margin:0 + internal padding so
+ * adjacent blocks' bars join seamlessly.
+ */
+const BODY_BLOCK_STYLE: CSSProperties = {
+  margin: 0,
+  borderLeft: `${BAR_WIDTH}px solid ${BAR_COLOR}`,
+  paddingLeft: BAR_PAD,
+  paddingTop: 2,
+  paddingBottom: 2,
+};
+
+/**
+ * Headings: bold, upright (not italic like the body), and barred like the body
+ * so the section reads as one unit. marginTop opens the gap that breaks the bar
+ * before this heading; marginBottom stays 0 so the heading joins its own body.
+ */
+const HEADING_STYLE: CSSProperties = {
+  ...BODY_BLOCK_STYLE,
+  marginTop: 14,
+  paddingTop: 4,
+  fontStyle: "normal",
+  fontWeight: 600,
+  fontSize: 16,
+  lineHeight: "24px",
+};
+
+/** Renders a reasoning section heading — bold, upright, barred (HEADING_STYLE). */
+const ReasoningHeading = ({ children }: { children?: React.ReactNode }) => (
+  <h3 style={HEADING_STYLE}>{children}</h3>
+);
+
+/** Minimal shape of the hast node react-markdown hands each renderer. */
+interface HastNode {
+  type: string;
+  tagName?: string;
+  value?: string;
+  children?: HastNode[];
+}
+
+/**
+ * Reports whether a paragraph node is really a standalone bold line the model
+ * wrote as a heading — e.g. `**Plan**` arrives as `<p><strong>…</strong></p>`,
+ * not a real heading. We treat those as headings so the bar breaks at them
+ * (models rarely emit `##` here).
+ */
+function isBoldOnlyParagraph(node?: HastNode): boolean {
+  const kids = (node?.children ?? []).filter(
+    (child) => !(child.type === "text" && !(child.value ?? "").trim()),
+  );
+  return (
+    kids.length === 1 &&
+    kids[0].type === "element" &&
+    kids[0].tagName === "strong"
+  );
+}
 
 interface ReasoningBlockProps {
   thoughts: ThoughtEvent[];
@@ -54,7 +128,7 @@ const PLACEHOLDER_DONE =
  * these strings are the UI-side copy for each phase.
  */
 function phaseLabel(streaming: boolean, status?: TurnStatus): string {
-  if (!streaming) return "Reasoning";
+  if (!streaming) return "Reasoning details";
   switch (status) {
     case "mcp":
       return "Querying data tools…";
@@ -118,7 +192,7 @@ export function ReasoningBlock({
           {label}
           <ChevronDownIcon
             className={`text-on-surface-variant transition-transform duration-150 ${
-              open ? "rotate-0" : "-rotate-90"
+              open ? "rotate-180" : "rotate-0"
             }`}
           />
         </span>
@@ -127,18 +201,35 @@ export function ReasoningBlock({
         <div
           className="mt-2 reasoning-markdown"
           style={{
+            marginLeft: BAR_CENTER_LEFT,
             fontFamily: FONT_LABEL,
             fontSize: 16,
             lineHeight: "28px",
-            color: COLOR_TEXT,
+            // Softer than the response body + italic + a left bar with
+            // indentation, so the reasoning reads as an aside distinct from
+            // the actual answer.
+            color: COLOR_REASONING,
+            fontStyle: "italic",
           }}
         >
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
-              p: ({ children }) => (
-                <p className="m-0 mb-2 last:mb-0">{children}</p>
-              ),
+              // Headings break the left bar (see HEADING_STYLE).
+              h1: ReasoningHeading,
+              h2: ReasoningHeading,
+              h3: ReasoningHeading,
+              h4: ReasoningHeading,
+              h5: ReasoningHeading,
+              h6: ReasoningHeading,
+              // A lone-bold paragraph is really a section heading (breaks the
+              // bar); everything else is a barred body paragraph.
+              p: ({ node, children }) =>
+                isBoldOnlyParagraph(node as unknown as HastNode) ? (
+                  <h3 style={HEADING_STYLE}>{children}</h3>
+                ) : (
+                  <p style={BODY_BLOCK_STYLE}>{children}</p>
+                ),
               strong: ({ children }) => (
                 <strong style={{ fontWeight: 600 }}>{children}</strong>
               ),
@@ -146,10 +237,18 @@ export function ReasoningBlock({
                 <em style={{ fontStyle: "italic" }}>{children}</em>
               ),
               ul: ({ children }) => (
-                <ul className="list-disc pl-5 mb-2 space-y-0.5">{children}</ul>
+                <ul
+                  className="list-disc space-y-0.5"
+                  style={{ ...BODY_BLOCK_STYLE, paddingLeft: BAR_INSET + 20 }}
+                >
+                  {children}
+                </ul>
               ),
               ol: ({ children }) => (
-                <ol className="list-decimal pl-5 mb-2 space-y-0.5">
+                <ol
+                  className="list-decimal space-y-0.5"
+                  style={{ ...BODY_BLOCK_STYLE, paddingLeft: BAR_INSET + 20 }}
+                >
                   {children}
                 </ol>
               ),

--- a/narratives/src/components/data_agent.tsx
+++ b/narratives/src/components/data_agent.tsx
@@ -211,7 +211,9 @@ function TurnView({ turn, index, isStreaming, onAsk }: TurnViewProps) {
           and out-classes the Tailwind `leading-*` helper in source order. */}
       <div
         data-turn-index={index}
-        className="self-end shrink-0 max-w-[85%] sm:max-w-[80%] px-4 sm:px-6 py-3 sm:py-4 rounded-[24px] text-body-large shadow-sm bg-user-msg text-on-surface break-words scroll-mt-4"
+        className={`self-end shrink-0 max-w-[85%] sm:max-w-[80%] px-4 sm:px-6 py-3 sm:py-4 rounded-[24px] text-body-large shadow-sm bg-user-msg text-on-surface break-words scroll-mt-4${
+          index > 0 ? " mt-3" : ""
+        }`}
         style={{ lineHeight: "28px" }}
       >
         {turn.userMessage}
@@ -223,30 +225,41 @@ function TurnView({ turn, index, isStreaming, onAsk }: TurnViewProps) {
 
       {/* Reasoning block — sparkle + "Reasoning" header, expanded by default.
           Always renders above the response card per Figma 3427-16715;
-          falls back to a status placeholder when the agent emits no thoughts. */}
-      <ReasoningBlock
-        thoughts={turn.thoughts}
-        streaming={isStreaming && turn.status !== "done" && turn.status !== "error"}
-        done={turn.status === "done"}
-        status={turn.status}
-      />
+          falls back to a status placeholder when the agent emits no thoughts.
+          Suppressed when the turn was stopped — we replace the half-finished
+          reasoning with the "Stopped per your request" note below. */}
+      {!turn.stopped && (
+        <ReasoningBlock
+          thoughts={turn.thoughts}
+          streaming={isStreaming && turn.status !== "done" && turn.status !== "error"}
+          done={turn.status === "done"}
+          status={turn.status}
+        />
+      )}
 
-      {/* Skeleton while the turn is streaming but no synthesis text has
-          arrived yet. Covers the full pre-text window: mcp (tools running),
-          kb (knowledge base lookup), and synthesis (model thinking before
-          first token). */}
-      {!turn.text &&
-        (turn.status === "mcp" ||
-          turn.status === "kb" ||
-          turn.status === "synthesis") && (
-          <div className="self-start w-full max-w-4xl">
-            <SkeletonCard query={turn.userMessage} />
-          </div>
-        )}
+      {/* Narrative loading box — only once the agent starts constructing the
+          narrative (the `synthesis` phase), not during mcp (tools running) or
+          kb (knowledge base lookup). Through those earlier phases the user
+          sees just the reasoning; the narrative box appears with its loading
+          state when synthesis begins, then fills in as text streams. */}
+      {!turn.text && turn.status === "synthesis" && (
+        <div className="self-start w-full max-w-4xl">
+          <SkeletonCard query={turn.userMessage} />
+        </div>
+      )}
 
-      {/* Streaming + final answer — full Figma AnswerPanel */}
-      {turn.text && (
+      {/* Streaming + final answer — full Figma AnswerPanel. Hidden when the
+          turn was stopped so we don't show a truncated partial answer. */}
+      {turn.text && !turn.stopped && (
         <AnswerPanel turn={turn} isStreaming={isStreaming} onAsk={onAsk} />
+      )}
+
+      {/* Stopped note — shown in place of the reasoning/answer when the user
+          aborts the turn via the Stop button. */}
+      {turn.stopped && (
+        <div className="self-start shrink-0 w-full max-w-4xl text-body-large text-on-surface-variant">
+          Stopped per your request
+        </div>
       )}
 
       {/* Error */}

--- a/narratives/src/components/drawer_session.tsx
+++ b/narratives/src/components/drawer_session.tsx
@@ -5,6 +5,8 @@
 import { useState, type ReactNode } from "react";
 import { Trash2, X, ArrowRight, ArrowLeft } from "lucide-react";
 import { NewChatIcon, ChatsIcon } from "./icons";
+import { NAV_CONFIG } from "../config/nav_config";
+import { useHashRoute } from "../hooks/use_hash_route";
 import {
   formatRelativeTime,
   useChatSession,
@@ -34,6 +36,19 @@ const FONT_DISPLAY = "var(--font-display)";
  */
 const COLOR_LABEL = "var(--color-subtle)";
 const COLOR_ARROW = "var(--color-on-surface)";
+/**
+ * Active-tab accent — the brand primary color (driven by the instance's brand
+ * config), used for the active tab's dot + text.
+ */
+const COLOR_ACTIVE = "var(--color-brand-primary)";
+/**
+ * Leading-icon column width in the menu rows (NewChatIcon/ChatsIcon render at
+ * 22px). The section-tab dot sits in a box of the same width so tab labels
+ * line up with the "New chat"/"Chats" labels above.
+ */
+const MENU_ICON_WIDTH = 22;
+/** Inactive section-tab label — a touch darker than the menu rows' subtle grey. */
+const COLOR_TAB_INACTIVE = "var(--color-muted)";
 
 /** The chats drawer: desktop left-anchored list and mobile two-level slide-in panel. */
 export function SessionDrawer() {
@@ -50,6 +65,10 @@ export function SessionDrawer() {
   // Which level the MOBILE panel is showing. Reset to "menu" whenever the
   // drawer closes so the next open always starts at the top level.
   const [view, setView] = useState<"menu" | "chats">("menu");
+
+  // Drives the active-tab highlight in the mobile menu's section nav below.
+  const [route] = useHashRoute();
+  const activeId = route || "agent";
 
   if (!isDrawerOpen) return null;
 
@@ -150,15 +169,69 @@ export function SessionDrawer() {
 
             <nav className="flex flex-col py-2 shrink-0">
               <MenuItem
-                icon={<NewChatIcon size="md" />}
-                label="New chat"
-                onClick={handleNewChat}
-              />
-              <MenuItem
                 icon={<ChatsIcon size="md" />}
                 label="Chats"
                 onClick={() => setView("chats")}
               />
+              <MenuItem
+                icon={<NewChatIcon size="md" />}
+                label="New chat"
+                onClick={handleNewChat}
+              />
+            </nav>
+
+            {/* Divider separating the chat controls above from the primary
+                section tabs below. Its left edge starts where the row labels
+                start: px-4 row padding (16) + the icon column (MENU_ICON_WIDTH)
+                + the gap-3 (12) between icon and label. */}
+            <div
+              className="shrink-0"
+              style={{ paddingLeft: 16 + MENU_ICON_WIDTH + 12, paddingRight: 16 }}
+            >
+              <div className="border-t border-outline" />
+            </div>
+
+            {/* Primary section tabs — the same four entries as the header nav
+                (NAV_CONFIG). The active tab gets a brand-primary dot + text.
+                The dot sits in a MENU_ICON_WIDTH box + gap-3, mirroring the
+                icon + gap-3 of the rows above so labels line up. */}
+            <nav className="flex flex-col py-2 shrink-0" aria-label="Sections">
+              {NAV_CONFIG.map((item) => {
+                const active = item.id === activeId;
+                return (
+                  <a
+                    key={item.id}
+                    href={item.href}
+                    aria-current={active ? "page" : undefined}
+                    onClick={close}
+                    className="w-full flex items-center gap-3 px-4 py-3 no-underline bg-transparent cursor-pointer hover:bg-surface-soft transition-colors"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="flex justify-center shrink-0"
+                      style={{ width: MENU_ICON_WIDTH }}
+                    >
+                      <span
+                        className="w-1.5 h-1.5 rounded-full"
+                        style={{
+                          background: active ? COLOR_ACTIVE : "transparent",
+                        }}
+                      />
+                    </span>
+                    <span
+                      style={{
+                        fontFamily: FONT_DISPLAY,
+                        fontSize: 15,
+                        lineHeight: "20px",
+                        fontWeight: 500,
+                        color: active ? COLOR_ACTIVE : COLOR_TAB_INACTIVE,
+                      }}
+                    >
+                      {item.label}
+                    </span>
+                  </a>
+                );
+              })}
             </nav>
           </div>
 
@@ -304,7 +377,10 @@ function MenuItem({
       onClick={onClick}
       className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left bg-transparent border-0 cursor-pointer hover:bg-surface-soft transition-colors"
     >
-      <span className="flex items-center gap-3" style={{ color: COLOR_LABEL }}>
+      <span
+        className="flex items-center gap-3"
+        style={{ color: COLOR_TAB_INACTIVE }}
+      >
         {icon}
         <span
           style={{

--- a/narratives/src/components/header.tsx
+++ b/narratives/src/components/header.tsx
@@ -11,11 +11,11 @@ import type { TokenUsage } from "../hooks/use_sse_chat";
 import { useBrand } from "../hooks/branding_context";
 
 /**
- * Temporary cost-instrumentation flag. When the page is opened with
- * `?debug=tokens`, the header shows per-query Gemini token usage. Off by
- * default so it never appears for normal users. Read once at module load.
+ * Reports whether the temporary token-usage readout is enabled — i.e. the page
+ * was opened with `?debug=tokens`. Evaluated per render (not at module load) so
+ * it reacts to client-side navigation and stays safe under SSR/tests.
  */
-const TOKEN_DEBUG_ENABLED =
+const isTokenDebugEnabled = () =>
   typeof window !== "undefined" &&
   new URLSearchParams(window.location.search).get("debug") === "tokens";
 
@@ -28,7 +28,7 @@ export function Header() {
   const { toggleDrawer, isDrawerOpen, turns } = useChatSession();
 
   // Latest turn that reported usage wins (later turns override earlier ones).
-  const latestUsage = TOKEN_DEBUG_ENABLED
+  const latestUsage = isTokenDebugEnabled()
     ? turns.reduce<TokenUsage | undefined>((acc, turn) => turn.usage ?? acc, undefined)
     : undefined;
 

--- a/narratives/src/components/header.tsx
+++ b/narratives/src/components/header.tsx
@@ -7,7 +7,17 @@ import { MenuIcon } from "./icons";
 import { NAV_CONFIG } from "../config/nav_config";
 import { useHashRoute } from "../hooks/use_hash_route";
 import { useChatSession } from "../hooks/chat_session_context";
+import type { TokenUsage } from "../hooks/use_sse_chat";
 import { useBrand } from "../hooks/branding_context";
+
+/**
+ * Temporary cost-instrumentation flag. When the page is opened with
+ * `?debug=tokens`, the header shows per-query Gemini token usage. Off by
+ * default so it never appears for normal users. Read once at module load.
+ */
+const TOKEN_DEBUG_ENABLED =
+  typeof window !== "undefined" &&
+  new URLSearchParams(window.location.search).get("debug") === "tokens";
 
 /** Renders the brand logo and the primary navigation tabs. */
 export function Header() {
@@ -15,10 +25,12 @@ export function Header() {
   const { logoUrl, instanceName } = useBrand();
   // Empty route → Agent (the default landing view).
   const activeId = route || "agent";
-  // The hamburger only drives the chat-sessions drawer, which is an
-  // Agent-tab concept — match the old Sidebar's `isAgent` gating.
-  const isAgent = route === "" || route === "agent";
-  const { toggleDrawer, isDrawerOpen } = useChatSession();
+  const { toggleDrawer, isDrawerOpen, turns } = useChatSession();
+
+  // Latest turn that reported usage wins (later turns override earlier ones).
+  const latestUsage = TOKEN_DEBUG_ENABLED
+    ? turns.reduce<TokenUsage | undefined>((acc, turn) => turn.usage ?? acc, undefined)
+    : undefined;
 
   return (
     <header className="w-full flex items-center justify-between gap-3 px-3 sm:px-6 lg:px-12 py-4 sm:py-5 shrink-0">
@@ -31,6 +43,20 @@ export function Header() {
         />
       </div>
 
+      {/* Temporary token-usage readout (only under ?debug=tokens). Sits between
+          the logo and the nav; shows the most recent query's Gemini usage so we
+          can gauge per-query cost. Not part of the shipped product UI. */}
+      {latestUsage && (
+        <div
+          className="hidden sm:block text-caption text-on-surface-variant leading-tight border border-outline rounded-md px-3 py-1.5 shrink-0"
+          aria-label="Token usage for the latest query"
+        >
+          <div>Tokens IN: {latestUsage.input.toLocaleString()}</div>
+          <div>Tokens OUT: {latestUsage.output.toLocaleString()}</div>
+          <div>Total: {latestUsage.total.toLocaleString()}</div>
+        </div>
+      )}
+
       {/* Right Navigation — horizontally scrollable on narrow screens so all
           tabs remain reachable without crowding the logo. */}
       <nav className="flex items-center gap-4 md:gap-6 lg:gap-8 text-label-large text-on-surface-variant ml-auto whitespace-nowrap overflow-x-auto no-scrollbar">
@@ -41,7 +67,9 @@ export function Header() {
               key={item.id}
               href={item.href}
               aria-current={isActive ? "page" : undefined}
-              className={`relative py-1 shrink-0 transition-colors ${
+              // Hidden below lg — on mobile these tabs live in the side drawer
+              // (SessionDrawer) instead, so the header nav stays uncluttered.
+              className={`relative py-1 shrink-0 transition-colors hidden lg:block ${
                 isActive ? "font-medium text-brand-primary" : "hover:text-on-surface"
               }`}
             >
@@ -53,7 +81,9 @@ export function Header() {
           );
         })}
 
-        <div className="hidden sm:block h-4 w-px bg-divider mx-1 shrink-0"></div>
+        {/* Divider before the language selector — only meaningful next to the
+            tabs, so it hides below lg alongside them. */}
+        <div className="hidden lg:block h-4 w-px bg-divider mx-1 shrink-0"></div>
 
         {/* TODO(i18n): language is hardcoded to English; move to branding config
             or wire up localization before exposing more languages. */}
@@ -69,23 +99,22 @@ export function Header() {
       </nav>
 
       {/* Mobile hamburger — replaces the static left rail below `lg`. Opens
-          the chat-sessions panel from the left. Sits at the far-right corner
-          of the header per design; hidden on desktop where the rail exists. */}
-      {isAgent && (
-        <button
-          type="button"
-          aria-label="Open menu"
-          aria-expanded={isDrawerOpen}
-          onClick={toggleDrawer}
-          className={`lg:hidden shrink-0 ml-1 w-10 h-10 flex items-center justify-center rounded-full transition-colors ${
-            isDrawerOpen
-              ? "bg-button-hover text-on-surface"
-              : "hover:bg-button-hover text-on-surface-variant"
-          }`}
-        >
-          <MenuIcon size="lg" />
-        </button>
-      )}
+          the menu drawer (section tabs + chat controls) from the right. Shown
+          on every tab, not just Agent, so the section nav inside the drawer is
+          reachable from all views; hidden on desktop where the rail exists. */}
+      <button
+        type="button"
+        aria-label="Open menu"
+        aria-expanded={isDrawerOpen}
+        onClick={toggleDrawer}
+        className={`lg:hidden shrink-0 ml-1 w-10 h-10 flex items-center justify-center rounded-full transition-colors ${
+          isDrawerOpen
+            ? "bg-button-hover text-on-surface"
+            : "hover:bg-button-hover text-on-surface-variant"
+        }`}
+      >
+        <MenuIcon size="lg" />
+      </button>
     </header>
   );
 }

--- a/narratives/src/hooks/use_sse_chat.ts
+++ b/narratives/src/hooks/use_sse_chat.ts
@@ -153,6 +153,20 @@ export type TurnStatus =
   | "done"
   | "error";
 
+/**
+ * Gemini token usage for one query, summed across every model call the agent
+ * made (MCP tool loop, KB, synthesis, chart config). `output` includes thinking
+ * tokens. Temporary cost instrumentation — surfaced only under ?debug=tokens.
+ */
+export interface TokenUsage {
+  /** Prompt (input) tokens billed. */
+  input: number;
+  /** Candidate + thinking (output) tokens billed. */
+  output: number;
+  /** Total tokens billed for the query. */
+  total: number;
+}
+
 /** Accumulated UI state for one user message and its streamed response. */
 export interface ChatTurn {
   userMessage: string;
@@ -165,7 +179,14 @@ export interface ChatTurn {
   provenance: ProvenanceItem[];
   /** Self-contained follow-up questions emitted by the agent after `done`. */
   followUps?: string[];
+  /** Token usage for this query; present once the agent emits its `usage` event. */
+  usage?: TokenUsage;
   error?: string;
+  /**
+   * Set when the user aborts the turn via Stop. Drives the "Stopped per your
+   * request" note in place of the (now-irrelevant) reasoning/answer chrome.
+   */
+  stopped?: boolean;
 }
 
 /**
@@ -189,6 +210,7 @@ interface SseEvent {
   mcp_sources?: ProvenanceItem[];
   kb_sources?: ProvenanceItem[];
   provenance?: ProvenanceItem[];
+  usage?: TokenUsage;
   done?: boolean;
   error?: string;
 }
@@ -355,9 +377,10 @@ export function useSseChat(props: UseSseChatProps): UseSseChatResult {
         }
       } catch (e) {
         if (e instanceof DOMException && e.name === "AbortError") {
-          // User clicked Stop — keep whatever partial content arrived and
-          // mark the turn as done rather than errored.
-          patch((turn) => ({ ...turn, status: "done" }));
+          // User clicked Stop — mark the turn done and flag it stopped so the
+          // UI shows a clear "Stopped per your request" note instead of the
+          // half-finished reasoning/answer.
+          patch((turn) => ({ ...turn, status: "done", stopped: true }));
         } else {
           const msg = e instanceof Error ? e.message : String(e);
           patch((turn) => ({ ...turn, status: "error", error: msg }));
@@ -449,6 +472,10 @@ function applyEvent(turn: ChatTurn, evt: SseEvent): ChatTurn {
       }
     }
     next = { ...next, provenance: merged };
+  }
+
+  if (evt.usage) {
+    next = { ...next, usage: evt.usage };
   }
 
   if (evt.done) {

--- a/narratives/src/hooks/use_sse_chat.ts
+++ b/narratives/src/hooks/use_sse_chat.ts
@@ -320,16 +320,17 @@ export function useSseChat(props: UseSseChatProps): UseSseChatResult {
       setError(null);
 
       // History sent to the agent excludes the current turn. The proxy
-      // expects a Gemini-format list (role + parts.text).
-      const history = turns.flatMap((turn) => {
-        const items: Array<{ role: string; parts: Array<{ text: string }> }> = [
+      // expects a Gemini-format list of strictly alternating user/model roles.
+      // Only completed turns that produced model text are included: a stopped
+      // or errored turn (especially one aborted before any text arrived) would
+      // otherwise emit a lone `user` entry, producing consecutive `user`
+      // messages that Gemini rejects with a 400.
+      const history = turns
+        .filter((turn) => !turn.stopped && turn.status === "done" && turn.text)
+        .flatMap((turn) => [
           { role: "user", parts: [{ text: turn.userMessage }] },
-        ];
-        if (turn.text) {
-          items.push({ role: "model", parts: [{ text: turn.text }] });
-        }
-        return items;
-      });
+          { role: "model", parts: [{ text: turn.text }] },
+        ]);
 
       // Applies a mutation to the in-flight turn, leaving other turns intact.
       const patch = (mutate: (turn: ChatTurn) => ChatTurn) =>


### PR DESCRIPTION
## Overview

Follow-up UI chunk for the narratives Data Agent, bringing the remaining
front-end refinements into the repo. No backend/build-config changes.

## Changes made

- **Stopped-turn UX**: when the user clicks Stop mid-stream, the half-finished
  reasoning/answer is replaced with a "Stopped per your request" note instead
  of leaving truncated chrome (`data_agent.tsx`, `block_reasoning.tsx`).
- **Reasoning-aside polish**: the reasoning section reads as a muted aside with
  a left bar; heading styling and spacing refined (`block_reasoning.tsx`).
- **Mobile drawer nav** refinements to the session drawer (`drawer_session.tsx`).
- **Token-usage readout (debug-only)**: a `Tokens IN / OUT / Total` block in the
  header, shown **only** when the page is opened with `?debug=tokens`. It reads
  an optional `usage` SSE event; off by default and invisible to normal users.
  Temporary instrumentation for gauging per-query cost (`header.tsx`,
  `use_sse_chat.ts`).

## Testing done

- [x] `npm run lint` (`tsc --noEmit`, strict) — clean.
- [x] `npm run build` (vite) — clean.
- [x] `npm test` (vitest) — passing.
