### PR TITLE
Narratives services image

### DIFF
--- a/narratives/.dockerignore
+++ b/narratives/.dockerignore
@@ -1,6 +1,13 @@
 node_modules
 dist
 .git
+
+# The services image builds only the React app. These sit inside the build
+# context but contribute nothing to it. Patterns match the context root only,
+# so src/config/ is unaffected.
+agent
+config
+
 .env
 .env.local
 .env.*.local

--- a/narratives/Dockerfile
+++ b/narratives/Dockerfile
@@ -31,7 +31,11 @@ COPY . .
 RUN npm run build
 
 # ---- Runtime stage: upstream services + our overlay -------------------------
-FROM --platform=linux/amd64 gcr.io/datcom-ci/datacommons-services:stable
+# The target platform comes from the builder (`build.sh` passes
+# --platform linux/amd64 and then fails if the result is not amd64). Pinning it
+# on the FROM line instead trips BuildKit's FromPlatformFlagConstDisallowed
+# warning and breaks multi-platform builds.
+FROM gcr.io/datcom-ci/datacommons-services:stable
 
 # The React build. nginx serves index.html at / and the hashed bundles from
 # /assets/*; public/ assets (logo.png, loader.png, send.svg) land here too.

--- a/narratives/Dockerfile
+++ b/narratives/Dockerfile
@@ -1,0 +1,53 @@
+# Services image — the ingress container for a Custom Data Commons instance.
+#
+# An overlay on the upstream Custom Data Commons image. It adds two things and
+# changes nothing else:
+#   1. The compiled React UI at /workspace/react-ui/.
+#   2. An nginx config that serves that build at / and /assets/*, proxies
+#      /agent/* to the agent sidecar on 127.0.0.1:${PROXY_PORT}, and leaves
+#      /core/api/*, /mcp and everything else routed to the upstream services
+#      (Flask :7070, Mixer/Envoy :8081, MCP :8082).
+#
+# This is one of the two containers in the Cloud Run service; the other is
+# built from agent/Dockerfile. When upstream cuts a new tag, only the FROM
+# below changes — the overlay itself is upstream-agnostic.
+#
+# Build context is narratives/, so `docker build -f narratives/Dockerfile` must
+# be given narratives/ as its context. build.sh handles that.
+
+# ---- Build stage: compile the React app -------------------------------------
+# The build runs here rather than on the host so the image is reproducible from
+# a clean clone: npm ci installs exactly the tree in package-lock.json, and no
+# pre-built dist/ has to be staged in beforehand.
+FROM node:20-alpine AS build
+
+WORKDIR /src
+
+# Copy the manifests first so this layer caches unless dependencies change.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ---- Runtime stage: upstream services + our overlay -------------------------
+FROM --platform=linux/amd64 gcr.io/datcom-ci/datacommons-services:stable
+
+# The React build. nginx serves index.html at / and the hashed bundles from
+# /assets/*; public/ assets (logo.png, loader.png, send.svg) land here too.
+COPY --from=build /src/dist /workspace/react-ui/
+
+# Replaces the upstream nginx config in place.
+COPY nginx.conf /workspace/nginx.conf
+
+# Inherit the upstream ENTRYPOINT/CMD — it starts nginx, Flask, Mixer, the MCP
+# server and the NL server together. Overriding it here would break the image.
+#
+# On running as root: the agent sidecar (agent/Dockerfile) drops to a dedicated
+# non-root user, and this image deliberately does not. It is a thin overlay on
+# an upstream image whose entrypoint supervises five processes and owns its own
+# filesystem layout; choosing the runtime user is upstream's decision, and
+# forcing one here would likely break nginx's pid/temp paths and the Flask and
+# NL servers' writable directories. Nothing this overlay adds needs write
+# access — the React build and nginx.conf are read-only at runtime. If upstream
+# publishes a non-root variant, switch the FROM tag and add USER here.

--- a/narratives/build.sh
+++ b/narratives/build.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Build and (optionally) push the services image to Artifact Registry.
+#
+# This is the ingress container: the upstream Custom Data Commons image plus the
+# compiled React UI and our nginx config. The agent sidecar is built separately
+# by agent/build.sh.
+#
+# The React build happens inside the Dockerfile, so nothing has to be built or
+# staged on the host first.
+#
+# Tag is the short git SHA so image and infra (Terraform tfvars) stay in sync.
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Build and (optionally) push the services image to Artifact Registry.
+
+Usage: ./build.sh [--push] [--help]
+
+Options:
+  --push    Push the built image (both the SHA tag and :latest) to AR.
+  --help    Show this help and exit.
+
+Environment overrides (with defaults):
+  AR_REGION   Artifact Registry region   (us-central1)
+  AR_REPO     Artifact Registry repo     (custom-dc)
+  PROJECT     GCP project                (gdatacomms)
+USAGE
+}
+
+# Resolve the script's own directory so docker build works regardless of the
+# caller's current working directory.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+PUSH=false
+for arg in "$@"; do
+    case "${arg}" in
+        --push) PUSH=true ;;
+        --help|-h) usage; exit 0 ;;
+        *)
+            echo "Error: unknown argument '${arg}'" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+AR_REGION="${AR_REGION:-us-central1}"
+AR_REPO="${AR_REPO:-custom-dc}"
+PROJECT="${PROJECT:-gdatacomms}"
+IMAGE_NAME="services"
+TAG="$(git rev-parse --short=12 HEAD)"
+
+IMAGE_BASE="${AR_REGION}-docker.pkg.dev/${PROJECT}/${AR_REPO}/${IMAGE_NAME}"
+FULL_IMAGE="${IMAGE_BASE}:${TAG}"
+LATEST_IMAGE="${IMAGE_BASE}:latest"
+
+echo "Building ${FULL_IMAGE}"
+echo "  PROJECT=${PROJECT} AR_REGION=${AR_REGION} AR_REPO=${AR_REPO}"
+
+docker buildx build \
+    --platform linux/amd64 \
+    -t "${FULL_IMAGE}" \
+    -t "${LATEST_IMAGE}" \
+    --load \
+    "${DIR}"
+
+# Verify amd64 — Cloud Run rejects arm64 silently.
+ARCH="$(docker inspect --format '{{.Architecture}}' "${FULL_IMAGE}")"
+if [[ "${ARCH}" != "amd64" ]]; then
+    echo "FATAL: image architecture is ${ARCH}, expected amd64" >&2
+    exit 1
+fi
+echo "  arch verified: ${ARCH}"
+
+if [[ "${PUSH}" == true ]]; then
+    echo "Pushing ${FULL_IMAGE}"
+    docker push "${FULL_IMAGE}"
+    docker push "${LATEST_IMAGE}"
+    echo "Done. Tag for tfvars: ${TAG}"
+fi

--- a/narratives/nginx.conf
+++ b/narratives/nginx.conf
@@ -1,0 +1,101 @@
+events {}
+
+http {
+  # Mime types for the static React assets — without this, browsers refuse
+  # to execute the .js bundle ("text/plain") and .css doesn't apply.
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  server {
+    listen 8080;
+
+    # ─── 1. Sidecar agent ────────────────────────────────────────────────
+    # The trailing slash on proxy_pass strips the /agent prefix so the agent
+    # sees /chat/stream, /brand, /api/tools, etc. Port must match PROXY_PORT
+    # in agent/Dockerfile.
+    location /agent/ {
+        proxy_pass http://127.0.0.1:5001/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 600;
+        proxy_send_timeout 600;
+        # SSE: the chat endpoint streams, so nothing may buffer it. Without
+        # these three the answer arrives only after the stream closes.
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+    }
+
+    # ─── 2. React UI ─────────────────────────────────────────────────────
+    # Static files served straight from the image: index.html at /, hashed
+    # JS/CSS at /assets/*, and the handful of bare files below.
+    location = / {
+        root /workspace/react-ui;
+        try_files /index.html =404;
+    }
+    location /assets/ {
+        root /workspace/react-ui;
+        access_log off;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+    # Bare static assets the app references from the site root. Keep this list
+    # in sync with public/ — anything not listed falls through to the upstream
+    # Flask app in section 5 and 404s there.
+    location ~ ^/(loader\.png|send\.svg|logo\.png)$ {
+        root /workspace/react-ui;
+        access_log off;
+        expires 1h;
+    }
+
+    # ─── 3. Mixer API (upstream, served at /core/api/) ───────────────────
+    location /core/api/ {
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With' always;
+            add_header 'Access-Control-Max-Age' 3600;
+            add_header 'Content-Length' 0;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            return 204;
+        }
+        rewrite /core/api/(.*) /$1 break;
+        proxy_pass http://localhost:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_read_timeout 3600;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,X-Requested-With' always;
+    }
+
+    # ─── 4. MCP server (upstream) ────────────────────────────────────────
+    # Must match MCP_PORT in agent/Dockerfile — the agent talks to the same
+    # server directly on localhost, bypassing nginx.
+    location /mcp {
+        proxy_pass http://localhost:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_read_timeout 3600;
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    # ─── 5. Everything else → upstream Flask ─────────────────────────────
+    # Covers /api/observations/*, /api/place/*, /place/*, /browser/*,
+    # /explore/*, /tools/*, /healthz, and any other upstream-managed path.
+    location / {
+        proxy_pass http://0.0.0.0:7070;
+        proxy_set_header Host $http_host;
+        proxy_read_timeout 3600;
+    }
+
+    error_log /dev/stderr;
+  }
+}


### PR DESCRIPTION
## Overview

Clear description of the changes.

Dockerfile — a thin overlay on the upstream Custom Data Commons image. Adds the compiled React app at /workspace/react-ui/ and replaces the nginx config; upstream's entrypoint, which supervises nginx, Flask, Mixer, MCP and the NL server, is left untouched.

The React build runs in a node stage inside the image rather than on the host. That keeps a clean clone reproducible — npm ci installs exactly the tree in package-lock.json — and avoids a pre-built dist/ having to be staged first. It also sidesteps .dockerignore, which excludes dist/ and would silently break a host-staged copy.
nginx.conf — routes:
| Path            | Goes to                             |
|-----------------|-------------------------------------|
| /agent/*        | the sidecar on [127.0.0.1:5001](http://127.0.0.1:5001/)       |
| /, /assets/*    | the React build, from the image     |
| /core/api/*     | Mixer on :8081, with CORS preflight |
| /mcp            | the MCP server on :8082             |
| everything else | upstream Flask on :7070             |