### PR TITLE
feat(data-weaver): adjust z-indexes and overlay positioning

### DIFF
--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/controls.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/controls.module.scss
@@ -1,8 +1,8 @@
 .container {
   position: fixed;
-  z-index: $z-index-menus;
   top: var(--controls-gutter-outer);
   right: var(--controls-gutter-outer);
+  z-index: $z-index-menus;
   display: flex;
   flex-wrap: wrap;
   gap: var(--controls-gutter-outer);

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/controls.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/controls.module.scss
@@ -1,5 +1,6 @@
 .container {
-  position: absolute;
+  position: fixed;
+  z-index: $z-index-menus;
   top: var(--controls-gutter-outer);
   right: var(--controls-gutter-outer);
   display: flex;

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/import/menu.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/import/menu.module.scss
@@ -1,8 +1,8 @@
 .menu {
   --menu-padding: 20px;
 
-  z-index: $z-index-menus;
   right: 0;
+  z-index: $z-index-menus;
   display: flex;
   flex-direction: column;
   width: 370px;

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/import/menu.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/import/menu.module.scss
@@ -1,6 +1,7 @@
 .menu {
   --menu-padding: 20px;
 
+  z-index: $z-index-menus;
   right: 0;
   display: flex;
   flex-direction: column;

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/index.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/index.module.scss
@@ -4,3 +4,10 @@
   z-index: $z-index-overlay;
   pointer-events: none;
 }
+
+.selection-container {
+  position: fixed;
+  inset: 0;
+  z-index: $z-index-above-content;
+  pointer-events: none;
+}

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/index.tsx
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/index.tsx
@@ -10,10 +10,14 @@ export const InFrontOfTheCanvas = () => {
   // that traps them below app content (page_home). The 'Portal' lifts their DOM
   // to above that content while keeping them in the editor's React tree
   return (
-    <Portal className={s.container}>
-      <Controls />
-      <Tools />
-      <Selection />
-    </Portal>
+    <>
+      <Portal className={s.container}>
+        <Controls />
+        <Tools />
+      </Portal>
+      <Portal className={s['selection-container']}>
+        <Selection />
+      </Portal>
+    </>
   );
 };

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection/selection.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection/selection.module.scss
@@ -10,6 +10,7 @@
 
 .actions-container {
   position: absolute;
+  z-index: $z-index-menus;
   top: 0;
   left: 50%;
   display: flex;

--- a/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection/selection.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/atlas/components/in_front_of_canvas/selection/selection.module.scss
@@ -10,9 +10,9 @@
 
 .actions-container {
   position: absolute;
-  z-index: $z-index-menus;
   top: 0;
   left: 50%;
+  z-index: $z-index-menus;
   display: flex;
   gap: 6px;
   align-items: center;

--- a/dataweaver/apps/web/src/components/scopes/page_home/page_home.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/page_home.module.scss
@@ -10,10 +10,10 @@
   --distance-from-left: var(--distance-from-right);
 
   position: fixed;
+  z-index: $z-index-prompts;
   right: var(--distance-from-right);
   bottom: var(--gutter);
   left: var(--distance-from-left);
-  z-index: $z-index-above-content;
   display: flex;
   flex-direction: column;
   row-gap: 16px;

--- a/dataweaver/apps/web/src/components/scopes/page_home/page_home.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/page_home.module.scss
@@ -10,10 +10,10 @@
   --distance-from-left: var(--distance-from-right);
 
   position: fixed;
-  z-index: $z-index-prompts;
   right: var(--distance-from-right);
   bottom: var(--gutter);
   left: var(--distance-from-left);
+  z-index: $z-index-prompts;
   display: flex;
   flex-direction: column;
   row-gap: 16px;

--- a/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
+++ b/dataweaver/apps/web/src/components/scopes/page_home/prompt.module.scss
@@ -16,7 +16,7 @@
   width: 100%;
   pointer-events: auto;
   background: rgb(var(--color-query-surface-raised));
-  border-radius: var(--border-radius-medium);
+  border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-elevated);
 
   &::before {

--- a/dataweaver/apps/web/src/styles/includes/_z-indices.module.scss
+++ b/dataweaver/apps/web/src/styles/includes/_z-indices.module.scss
@@ -9,5 +9,7 @@ $-next-z-index: 0;
 $z-index-behind-content: -1;
 $z-index-content: 0;
 $z-index-above-content: -get-next-z-index();
+$z-index-prompts: -get-next-z-index();
 $z-index-overlay: -get-next-z-index();
+$z-index-menus: -get-next-z-index();
 $z-index-toaster: -get-next-z-index();

--- a/dataweaver/packages/tokens/src/colors.json
+++ b/dataweaver/packages/tokens/src/colors.json
@@ -7,7 +7,9 @@
 
   "surface-raised": [255, 255, 255],
   "surface-dimmed": [247, 252, 255],
+  "surface-faded": [245, 250, 255],
   "surface-subtle": [248, 249, 252],
+  "surface-strong": [249, 250, 252],
   "surface-muted": [227, 231, 237],
 
   "content": [32, 33, 36],
@@ -19,7 +21,7 @@
   "transparent": [0, 0, 0, 0],
   "outline": [0, 0, 0],
 
-  "atlas-surface": "$surface-dimmed",
+  "atlas-surface": "$surface-strong",
   "atlas-decorator": "$surface-muted",
   "atlas-content": "$shadow",
   "atlas-accent": "$accent",
@@ -86,7 +88,7 @@
   "tag-border": "$accent",
   "tag-content": "$content",
 
-  "card-surface": "$surface-raised",
+  "card-surface": "$surface-faded",
   "card-surface-selected": "$accent",
   "card-content": "$content",
   "card-content-muted": "$content-muted",


### PR DESCRIPTION
## Overview

This PR address the following
- Update input box corners
- Group selection on top of AI-thinking-Card
- Update colors for tiles and canvas backgrounds

## Related Issues

Fixes # (issue number)

## Changes Made

- Lift UI overlays above page content: switch controls/selection containers to fixed positioning and move Selection into its own Portal.
- Add $z-index-prompts and $z-index-menus and apply them to controls, menus, selection and prompts.
- Small UI tweaks: increase prompt border-radius.
- Update color tokens by adding surface-faded and surface-strong, and change atlas-surface and card-surface to use the new tokens.
- Changes touch in_front_of_canvas components, page_home styles, _z-indices, and tokens/colors.json.

<img width="1047" height="570" alt="Screenshot 2026-08-21 at 12 47 42 AM" src="https://github.com/user-attachments/assets/68b4f6b5-b769-4de1-aeae-b82fd47ba697" />

## Testing Done
Describe the steps you took to test these changes (please also list commands ran if possible).

- [ ] Unit tests passed
- [ ] Integration tests passed
- [x] Manual verification

## Checklist

- [x] I have followed the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

---
*Note: Only Maintainers can approve and merge PRs. Expected initial review time: 3 business days.*

