### PR TITLE
feat(data-weaver): implement generic fetch nodes

### DIFF
--- a/dataweaver/apps/web/src/server/clients/dc_api.test.ts
+++ b/dataweaver/apps/web/src/server/clients/dc_api.test.ts
@@ -2,15 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchChildPlaces, fetchNodes } from './dc_api';
 
 describe('dc_api client', () => {
-  const originalEnv = process.env.DATA_COMMONS_API_KEY;
-
   beforeEach(() => {
-    process.env.DATA_COMMONS_API_KEY = 'test-key';
+    vi.stubEnv('DATA_COMMONS_API_KEY', 'test-key');
     vi.restoreAllMocks();
   });
 
   afterEach(() => {
-    process.env.DATA_COMMONS_API_KEY = originalEnv;
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -19,7 +17,7 @@ describe('dc_api client', () => {
     // Situation: DATA_COMMONS_API_KEY is not set in environment.
     // Expectation: fetchNodes throws an error indicating the missing API key.
     it('throws if DATA_COMMONS_API_KEY is not configured', async () => {
-      delete process.env.DATA_COMMONS_API_KEY;
+      vi.stubEnv('DATA_COMMONS_API_KEY', '');
       await expect(
         fetchNodes(['country/FRA'], '->geoJsonCoordinates'),
       ).rejects.toThrow('DATA_COMMONS_API_KEY environment variable is not set');
@@ -41,11 +39,10 @@ describe('dc_api client', () => {
         },
       };
 
-      const fetchMock = vi.fn().mockResolvedValue({
+      const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,
         json: async () => mockResponse,
-      });
-      globalThis.fetch = fetchMock;
+      } as Response);
 
       const result = await fetchNodes(['country/FRA'], '->geoJsonCoordinates');
       expect(result).toEqual(mockResponse);
@@ -86,10 +83,10 @@ describe('dc_api client', () => {
         },
       };
 
-      globalThis.fetch = vi.fn().mockResolvedValue({
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,
         json: async () => mockResponse,
-      });
+      } as Response);
 
       const children = await fetchChildPlaces('europe');
       expect(children).toEqual([

--- a/dataweaver/apps/web/src/server/clients/dc_api.test.ts
+++ b/dataweaver/apps/web/src/server/clients/dc_api.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchChildPlaces, fetchNodes } from './dc_api';
+
+describe('dc_api client', () => {
+  const originalEnv = process.env.DATA_COMMONS_API_KEY;
+
+  beforeEach(() => {
+    process.env.DATA_COMMONS_API_KEY = 'test-key';
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.DATA_COMMONS_API_KEY = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchNodes', () => {
+    // Test: Missing API key handling.
+    // Situation: DATA_COMMONS_API_KEY is not set in environment.
+    // Expectation: fetchNodes throws an error indicating the missing API key.
+    it('throws if DATA_COMMONS_API_KEY is not configured', async () => {
+      delete process.env.DATA_COMMONS_API_KEY;
+      await expect(
+        fetchNodes(['country/FRA'], '->geoJsonCoordinates'),
+      ).rejects.toThrow('DATA_COMMONS_API_KEY environment variable is not set');
+    });
+
+    // Test: Successful node query.
+    // Situation: Valid API key, querying nodes and property.
+    // Expectation: Sends POST request to /v2/node with correct payload and headers and returns parsed JSON.
+    it('queries /v2/node with correct headers and payload', async () => {
+      const mockResponse = {
+        data: {
+          'country/FRA': {
+            arcs: {
+              geoJsonCoordinates: {
+                nodes: [{ value: '{"type":"Polygon","coordinates":[]}' }],
+              },
+            },
+          },
+        },
+      };
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+      globalThis.fetch = fetchMock;
+
+      const result = await fetchNodes(['country/FRA'], '->geoJsonCoordinates');
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/v2/node'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'X-API-Key': 'test-key',
+          }),
+          body: JSON.stringify({
+            nodes: ['country/FRA'],
+            property: '->geoJsonCoordinates',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('fetchChildPlaces', () => {
+    // Test: Child place extraction.
+    // Situation: /v2/node returns child place graph arcs for a parent place.
+    // Expectation: Extracts and returns an array of ChildPlace objects.
+    it('extracts child place nodes from /v2/node response', async () => {
+      const mockResponse = {
+        data: {
+          europe: {
+            arcs: {
+              '<-containedInPlace+': {
+                nodes: [
+                  { dcid: 'country/FRA', name: 'France', types: ['Country'] },
+                  { dcid: 'country/DEU', name: 'Germany', types: ['Country'] },
+                ],
+              },
+            },
+          },
+        },
+      };
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const children = await fetchChildPlaces('europe');
+      expect(children).toEqual([
+        { dcid: 'country/FRA', name: 'France', types: ['Country'] },
+        { dcid: 'country/DEU', name: 'Germany', types: ['Country'] },
+      ]);
+    });
+  });
+});

--- a/dataweaver/apps/web/src/server/clients/dc_api.ts
+++ b/dataweaver/apps/web/src/server/clients/dc_api.ts
@@ -57,26 +57,18 @@ export interface ObservationResponse {
   >;
 }
 
-/** Fetch direct child places contained within a parent place using Data Commons V2 /v2/node. */
-export const fetchChildPlaces = async (
-  parentDcid: string,
-  childPlaceType?: string,
+/** Query Data Commons V2 /v2/node for properties and connected graph nodes. */
+export const fetchNodes = async (
+  nodes: string[],
+  property: string,
   signal?: AbortSignal,
-): Promise<ChildPlace[]> => {
+): Promise<NodeResponse> => {
   const apiKey = process.env.DATA_COMMONS_API_KEY;
   if (!apiKey)
     throw new Error('DATA_COMMONS_API_KEY environment variable is not set');
 
   const config = getServiceConfig();
   const baseUrl = config.api.dataCommons.baseUrl;
-
-  const normalizedType = childPlaceType
-    ? normalizePlaceType(childPlaceType)
-    : undefined;
-
-  const property = normalizedType
-    ? `<-containedInPlace+{typeOf:${normalizedType}}`
-    : '<-containedInPlace+';
 
   const res = await fetch(`${baseUrl}/v2/node`, {
     method: 'POST',
@@ -85,14 +77,31 @@ export const fetchChildPlaces = async (
       'X-API-Key': apiKey,
     },
     body: JSON.stringify({
-      nodes: [parentDcid],
+      nodes,
       property,
     }),
     signal,
   });
 
   if (!res.ok) throw new Error(`DC API Error: ${res.status} ${res.statusText}`);
-  const json: NodeResponse = await res.json();
+  return res.json();
+};
+
+/** Fetch direct child places contained within a parent place using Data Commons V2 /v2/node. */
+export const fetchChildPlaces = async (
+  parentDcid: string,
+  childPlaceType?: string,
+  signal?: AbortSignal,
+): Promise<ChildPlace[]> => {
+  const normalizedType = childPlaceType
+    ? normalizePlaceType(childPlaceType)
+    : undefined;
+
+  const property = normalizedType
+    ? `<-containedInPlace+{typeOf:${normalizedType}}`
+    : '<-containedInPlace+';
+
+  const json = await fetchNodes([parentDcid], property, signal);
 
   const nodeArcs = json.data?.[parentDcid]?.arcs;
   if (!nodeArcs) return [];


### PR DESCRIPTION
## Description

This PR extracts a reusable `fetchNodes` client helper for querying the Data Commons V2 `/v2/node` endpoint and add unit test coverage for the `dc_api` client.

The proximate reason for this refactor and the generic function (rather than a single direct fetchChildPlaces) is that upcoming functionality to fetch GeoJSON for the choropleths will use this. More generally, a fetchNodes function could prove to be useful for other purposes later.

## Testing
* Added unit tests in `dc_api.test.ts` covering missing API key errors, `/v2/node` request structure, and child place parsing.
* Verified test suite.
* Verified lint and type checks with `pnpm lint`.
* Verified build and build runtime

Note: this does not fix formatting, as a separate open PR does this.