### PR TITLE
feat(data-weaver): add friendly tool call labels and remove misleading counts

### DIFF
--- a/dataweaver/apps/web/src/app/api/query/route.ts
+++ b/dataweaver/apps/web/src/app/api/query/route.ts
@@ -313,7 +313,7 @@ export async function POST(request: NextRequest) {
               emit({ type: STREAM_EVENT.toolCall, tool: e.tool, args: e.args });
               emit({
                 type: STREAM_EVENT.status,
-                message: STATUS.usingTool(e.tool, e.count, e.max),
+                message: STATUS.usingTool(e.tool),
               });
             },
           });

--- a/dataweaver/apps/web/src/server/status.test.ts
+++ b/dataweaver/apps/web/src/server/status.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { STATUS, TOOL_LABELS } from '~/server/types';
+
+describe('STATUS.usingTool', () => {
+  // Test: Exports TOOL_LABELS mapping for Data Commons MCP tools.
+  // Situation: Validating known tool keys in TOOL_LABELS.
+  // Expectation: Contains expected friendly labels for all known tools.
+  it('defines friendly labels in TOOL_LABELS', () => {
+    expect(TOOL_LABELS.search_indicators).toBe('Searching variables');
+    expect(TOOL_LABELS.get_observations).toBe('Retrieving observations');
+  });
+  // Test: Maps known Data Commons MCP tools to human-readable action strings.
+  // Situation: Gemini calls an MCP tool that has a defined entry in TOOL_LABELS.
+  // Expectation: Formats the status with the friendly label and ellipsis without counts.
+  it('maps known MCP tools to friendly action strings', () => {
+    expect(STATUS.usingTool('search_indicators')).toBe(
+      'Searching variables...',
+    );
+    expect(STATUS.usingTool('search_child_indicators')).toBe(
+      'Searching regional variables...',
+    );
+    expect(STATUS.usingTool('get_variable_metadata')).toBe(
+      'Retrieving variable metadata...',
+    );
+    expect(STATUS.usingTool('get_observations')).toBe(
+      'Retrieving observations...',
+    );
+    expect(STATUS.usingTool('get_child_observations')).toBe(
+      'Retrieving regional observations...',
+    );
+    expect(STATUS.usingTool('get_multi_entity_observations')).toBe(
+      'Retrieving comparative observations...',
+    );
+    expect(STATUS.usingTool('resolve_entities')).toBe('Resolving places...');
+    expect(STATUS.usingTool('find_entities')).toBe('Finding places...');
+    expect(STATUS.usingTool('get_place_metadata')).toBe(
+      'Fetching place data...',
+    );
+  });
+
+  // Test: Falls back to clean label when an unmapped tool name is encountered.
+  // Situation: A tool is called that is not registered in TOOL_LABELS.
+  // Expectation: Formats the status as "Using tool: <tool>..." without denominator/count.
+  it('falls back to "Using tool: <tool>..." for unmapped tools', () => {
+    expect(STATUS.usingTool('custom_new_tool')).toBe(
+      'Using tool: custom_new_tool...',
+    );
+  });
+});

--- a/dataweaver/apps/web/src/server/types.ts
+++ b/dataweaver/apps/web/src/server/types.ts
@@ -176,6 +176,18 @@ export interface CombineStreamRequest {
 
 // --- Status messages ---
 
+export const TOOL_LABELS: Record<string, string> = {
+  search_indicators: 'Searching variables',
+  search_child_indicators: 'Searching regional variables',
+  get_variable_metadata: 'Retrieving variable metadata',
+  get_observations: 'Retrieving observations',
+  get_child_observations: 'Retrieving regional observations',
+  get_multi_entity_observations: 'Retrieving comparative observations',
+  resolve_entities: 'Resolving places',
+  find_entities: 'Finding places',
+  get_place_metadata: 'Fetching place data',
+};
+
 export const STATUS = {
   // Terminal states (for programmatic checks)
   idle: '',
@@ -193,8 +205,8 @@ export const STATUS = {
   // Dynamic messages
   discoveringMetrics: (place: string, current: number, total: number) =>
     `Discovering metrics for ${place} (${current}/${total})...`,
-  usingTool: (tool: string, count: number, max: number) =>
-    `Using tool: ${tool} (${count}/${max})...`,
+  usingTool: (tool: string) =>
+    `${TOOL_LABELS[tool] ?? `Using tool: ${tool}`}...`,
   noResponse: (place: string) => `No response for ${place}, skipping...`,
   buildingResults: (place: string) => `Building results for ${place}...`,
   invalidResponse: (place: string) =>


### PR DESCRIPTION
## Description

This PR maps low-level Data Commons MCP tool identifiers to human-readable status labels during streaming queries to improve the user-facing discovery experience.

It also removes the display of the model call iteration count and the denominator (count/max), because the max was misleading, as it was the maximum allowable calls, not the expected number (and the searches usually resolve in far fewer calls than the maximum).

## Notes

The friendly labels for tool calls were chosen with the intention of providing clean looking descriptions that would make sense to the user. They are open to other options. 

## Testing
* Added unit tests in `apps/web/src/server/status.test.ts` covering known tool mappings and fallback behavior.
* Verified production build and production build runtime via `pnpm build` and `pnpm preview`.