### PR TITLE
feat(data-weaver): improve tooltips and legends

### DIFF
--- a/dataweaver/apps/web/src/components/elements/card/chart/chart.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/chart.tsx
@@ -153,7 +153,10 @@ export const CardChart = ({
     currentFacet?.unit,
   ]);
 
-  const chartSeries = baseSeries;
+  const chartSeries = useMemo(() => {
+    if (!baseSeries || baseSeries.length <= 1) return baseSeries;
+    return [...baseSeries].sort((a, b) => a.label.localeCompare(b.label));
+  }, [baseSeries]);
 
   // Default to line chart when data has many points; allow manual override.
   const totalPoints = chartSeries
@@ -215,9 +218,9 @@ export const CardChart = ({
                 </div>
               )}
 
-              {seriesFacets && seriesProp && (
+              {seriesFacets && chartSeries && (
                 <div className={s['facet-selectors-container']}>
-                  {seriesProp.map((entry) => {
+                  {chartSeries.map((entry) => {
                     const facetList = seriesFacets[entry.key];
                     if (!facetList || facetList.length === 0) {
                       return null;

--- a/dataweaver/apps/web/src/components/elements/card/chart/chart.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/chart.tsx
@@ -153,10 +153,7 @@ export const CardChart = ({
     currentFacet?.unit,
   ]);
 
-  const chartSeries = useMemo(() => {
-    if (!baseSeries || baseSeries.length <= 1) return baseSeries;
-    return [...baseSeries].sort((a, b) => a.label.localeCompare(b.label));
-  }, [baseSeries]);
+  const chartSeries = baseSeries;
 
   // Default to line chart when data has many points; allow manual override.
   const totalPoints = chartSeries
@@ -218,9 +215,9 @@ export const CardChart = ({
                 </div>
               )}
 
-              {seriesFacets && chartSeries && (
+              {seriesFacets && seriesProp && (
                 <div className={s['facet-selectors-container']}>
-                  {chartSeries.map((entry) => {
+                  {seriesProp.map((entry) => {
                     const facetList = seriesFacets[entry.key];
                     if (!facetList || facetList.length === 0) {
                       return null;

--- a/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.module.scss
+++ b/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.module.scss
@@ -1,8 +1,7 @@
 .tooltip {
-  @include type-label-medium(false);
+  @include type-label-small(false);
 
   padding: 10px 12px;
-  font-weight: 700;
   color: rgb(var(--color-card-content));
   background-color: rgb(var(--color-card-surface));
   border-radius: 8px;
@@ -15,17 +14,18 @@
   .label {
     @include type-label-small(false);
 
-    margin-bottom: 4px;
+    margin-top: 6px;
+    margin-bottom: 0;
     color: rgb(var(--color-card-chart-tooltip-date));
   }
 
   .entry {
     display: flex;
-    gap: 6px;
+    gap: 8px;
     align-items: center;
 
     & + & {
-      margin-top: 2px;
+      margin-top: 4px;
     }
   }
 
@@ -40,9 +40,17 @@
     @include type-label-small(false);
 
     color: rgb(var(--color-card-content-muted));
+    white-space: nowrap;
   }
 
   .value {
-    @include type-label-medium(false);
+    @include type-label-small(false);
+
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .name ~ .value {
+    margin-left: auto;
   }
 }

--- a/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.test.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.test.tsx
@@ -1,0 +1,171 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import type { ChartSeries } from './chart';
+import { getSeriesColor } from './palette';
+import { TooltipCustom } from './tooltip_custom';
+
+describe('TooltipCustom', () => {
+  const singleSeries: ChartSeries[] = [
+    {
+      key: 'geoId/06',
+      label: 'California',
+      data: [{ date: '2020', value: 39538223 }],
+    },
+  ];
+
+  const multiSeries: ChartSeries[] = [
+    {
+      key: 'geoId/06',
+      label: 'California',
+      data: [{ date: '2020', value: 39538223 }],
+    },
+    {
+      key: 'geoId/48',
+      label: 'Texas',
+      data: [{ date: '2020', value: 29145505 }],
+    },
+  ];
+
+  // Test: Inactive or empty tooltip
+  // Situation: `active` is false or `payload` is empty.
+  // Expectation: Renders nothing.
+  it('returns null when inactive or payload is empty', () => {
+    const htmlInactive = renderToStaticMarkup(
+      <TooltipCustom
+        active={false}
+        payload={[{ value: 100, dataKey: 'value_0' }]}
+        series={singleSeries}
+      />,
+    );
+    expect(htmlInactive).toBe('');
+
+    const htmlEmpty = renderToStaticMarkup(
+      <TooltipCustom active={true} payload={[]} series={singleSeries} />,
+    );
+    expect(htmlEmpty).toBe('');
+  });
+
+  // Test: Single-series tooltip rendering
+  // Situation: A chart with 1 series and a single payload entry.
+  // Expectation: Renders formatted value and date label, without color swatch or series discriminator name.
+  it('renders value and date without swatch or series discriminator in single-series mode', () => {
+    const html = renderToStaticMarkup(
+      <TooltipCustom
+        active={true}
+        payload={[{ value: 39538223, dataKey: 'value_0' }]}
+        label="2020"
+        series={singleSeries}
+      />,
+    );
+
+    expect(html).toContain('39,538,223');
+    expect(html).toContain('in 2020');
+    expect(html).not.toContain('California');
+    expect(html).not.toContain('style="background-color:');
+  });
+
+  // Test: Multi-series tooltip rendering
+  // Situation: A chart with multiple series (e.g. California, Texas) and multiple payload entries.
+  // Expectation: Renders color swatch, series discriminator name for each series, and formatted values.
+  it('renders series discriminators and swatches when more than one series is present', () => {
+    const html = renderToStaticMarkup(
+      <TooltipCustom
+        active={true}
+        payload={[
+          { value: 39538223, dataKey: 'value_0', name: 'California' },
+          { value: 29145505, dataKey: 'value_1', name: 'Texas' },
+        ]}
+        label="2020"
+        series={multiSeries}
+      />,
+    );
+
+    expect(html).toContain('California');
+    expect(html).toContain('Texas');
+    expect(html).toContain('39,538,223');
+    expect(html).toContain('29,145,505');
+    expect(html).toContain(`background-color:${getSeriesColor(0)}`);
+    expect(html).toContain(`background-color:${getSeriesColor(1)}`);
+    expect(html).toContain('in 2020');
+  });
+
+  // Test: Fallback to series label when payload name is missing
+  // Situation: Payload entry does not include `name`, but series has `label`.
+  // Expectation: Discriminator name falls back to series label at that index.
+  it('falls back to series.label if entry.name is absent', () => {
+    const html = renderToStaticMarkup(
+      <TooltipCustom
+        active={true}
+        payload={[
+          { value: 39538223, dataKey: 'value_0' },
+          { value: 29145505, dataKey: 'value_1' },
+        ]}
+        label="2020"
+        series={multiSeries}
+      />,
+    );
+
+    expect(html).toContain('California');
+    expect(html).toContain('Texas');
+  });
+
+  // Test: Correct matching by series label independently of dataKey
+  // Situation: Payload contains entry with name "Texas" and arbitrary dataKey.
+  // Expectation: Correctly associates the entry with Texas series and its color.
+  it('matches series by label independently of dataKey naming', () => {
+    const html = renderToStaticMarkup(
+      <TooltipCustom
+        active={true}
+        payload={[{ value: 29145505, dataKey: 'custom_key', name: 'Texas' }]}
+        label="2020"
+        series={multiSeries}
+      />,
+    );
+
+    expect(html).toContain('Texas');
+    expect(html).not.toContain('California');
+    expect(html).toContain(`background-color:${getSeriesColor(1)}`);
+  });
+
+  // Test: Null value handling in multi-series tooltip
+  // Situation: A series has null value for a given observation point.
+  // Expectation: Renders "—" for the value while still displaying the series discriminator name and swatch.
+  it('displays "—" for null or undefined values in multi-series mode', () => {
+    const html = renderToStaticMarkup(
+      <TooltipCustom
+        active={true}
+        payload={[
+          { value: 39538223, dataKey: 'value_0', name: 'California' },
+          { value: null, dataKey: 'value_1', name: 'Texas' },
+        ]}
+        label="2020"
+        series={multiSeries}
+      />,
+    );
+
+    expect(html).toContain('California');
+    expect(html).toContain('39,538,223');
+    expect(html).toContain('Texas');
+    expect(html).toContain('—');
+  });
+
+  // Test: NaN value handling
+  // Situation: An entry has NaN as its value.
+  // Expectation: Renders "—" instead of the literal string "NaN".
+  it('displays "—" when value is NaN instead of literal NaN string', () => {
+    const html = renderToStaticMarkup(
+      <TooltipCustom
+        active={true}
+        payload={[
+          { value: Number.NaN, dataKey: 'value_0', name: 'California' },
+        ]}
+        label="2020"
+        series={singleSeries}
+      />,
+    );
+
+    expect(html).not.toContain('NaN');
+    expect(html).toContain('—');
+  });
+});

--- a/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.test.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.test.tsx
@@ -168,4 +168,52 @@ describe('TooltipCustom', () => {
     expect(html).not.toContain('NaN');
     expect(html).toContain('—');
   });
+
+  // Test: Alphabetized multi-series rendering order
+  // Situation: Chart has 3 series alphabetized upstream (Alaska, California, Texas).
+  // Expectation: Tooltip renders entries in that exact alphabetical order with corresponding palette colors.
+  it('renders entries in upstream alphabetical series order with matching swatches', () => {
+    const sortedSeries: ChartSeries[] = [
+      {
+        key: 'geoId/02',
+        label: 'Alaska',
+        data: [{ date: '2020', value: 733391 }],
+      },
+      {
+        key: 'geoId/06',
+        label: 'California',
+        data: [{ date: '2020', value: 39538223 }],
+      },
+      {
+        key: 'geoId/48',
+        label: 'Texas',
+        data: [{ date: '2020', value: 29145505 }],
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <TooltipCustom
+        active={true}
+        payload={[
+          { value: 733391, dataKey: 'value_0', name: 'Alaska' },
+          { value: 39538223, dataKey: 'value_1', name: 'California' },
+          { value: 29145505, dataKey: 'value_2', name: 'Texas' },
+        ]}
+        label="2020"
+        series={sortedSeries}
+      />,
+    );
+
+    const alaskaIdx = html.indexOf('Alaska');
+    const californiaIdx = html.indexOf('California');
+    const texasIdx = html.indexOf('Texas');
+
+    expect(alaskaIdx).toBeGreaterThan(-1);
+    expect(californiaIdx).toBeGreaterThan(alaskaIdx);
+    expect(texasIdx).toBeGreaterThan(californiaIdx);
+
+    expect(html).toContain(`background-color:${getSeriesColor(0)}`);
+    expect(html).toContain(`background-color:${getSeriesColor(1)}`);
+    expect(html).toContain(`background-color:${getSeriesColor(2)}`);
+  });
 });

--- a/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.tsx
+++ b/dataweaver/apps/web/src/components/elements/card/chart/tooltip_custom.tsx
@@ -2,10 +2,10 @@ import { formatChartValue } from '~/functions/format_chart_value';
 
 import type { ChartSeries } from './chart';
 import { getSeriesColor } from './palette';
-import styles from './tooltip_custom.module.scss';
+import s from './tooltip_custom.module.scss';
 
 interface TooltipEntry {
-  value: number;
+  value: number | null;
   dataKey?: string;
   name?: string;
   color?: string;
@@ -31,27 +31,38 @@ export const TooltipCustom = ({
   const isMulti = series && series.length > 1;
 
   return (
-    <div className={styles.tooltip}>
+    <div className={s.tooltip}>
       {payload.map((entry, index) => {
-        const color = isMulti ? getSeriesColor(index) : entry.color;
-        const entryUnit = series?.[index]?.unit ?? unit;
+        const currentSeries =
+          (entry.name && series?.find((s) => s.label === entry.name)) ||
+          series?.[index];
+        const seriesIndex =
+          currentSeries && series ? series.indexOf(currentSeries) : index;
+        const seriesName = entry.name || currentSeries?.label;
+        const color = isMulti ? getSeriesColor(seriesIndex) : entry.color;
+        const entryUnit = currentSeries?.unit ?? unit;
+        const isValueValid =
+          entry.value !== null &&
+          entry.value !== undefined &&
+          !Number.isNaN(Number(entry.value));
+
         return (
-          <div key={entry.dataKey ?? index} className={styles.entry}>
+          <div key={entry.dataKey ?? index} className={s.entry}>
             {isMulti && color && (
-              <span
-                className={styles.swatch}
-                style={{ backgroundColor: color }}
-              />
+              <span className={s.swatch} style={{ backgroundColor: color }} />
             )}
-            <span className={styles.value}>
-              {entry.value !== null && entry.value !== undefined
+            {isMulti && seriesName && (
+              <span className={s.name}>{seriesName}</span>
+            )}
+            <span className={s.value}>
+              {isValueValid
                 ? formatChartValue(Number(entry.value), entryUnit, 'standard')
                 : '—'}
             </span>
           </div>
         );
       })}
-      {label && <p className={styles.label}>in {`${label}`}</p>}
+      {label && <p className={s.label}>in {`${label}`}</p>}
     </div>
   );
 };

--- a/dataweaver/apps/web/src/components/scopes/atlas/sync_store.test.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/sync_store.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ComparisonResult, QueryResult } from '~/server/types';
+import {
+  deriveChartContent,
+  deriveChartContentForVariable,
+  deriveComparisonChartContent,
+} from './sync_store';
+
+describe('sync_store multi-series alphabetization', () => {
+  const sampleObservations = [{ date: '2020', value: 100 }];
+
+  // Test: deriveChartContent multi-entity alphabetization
+  // Situation: QueryResult contains multiple entities in non-alphabetical order (Texas, Alaska, California).
+  // Expectation: Resulting chart series are sorted alphabetically by label (Alaska, California, Texas).
+  it('alphabetizes series by entity name in deriveChartContent', () => {
+    const result: QueryResult = {
+      id: 'res-1',
+      title: 'Population',
+      variables: [{ dcid: 'Count_Person', name: 'Population' }],
+      entities: [
+        { dcid: 'geoId/48', name: 'Texas' },
+        { dcid: 'geoId/02', name: 'Alaska' },
+        { dcid: 'geoId/06', name: 'California' },
+      ],
+      timeSeries: [
+        {
+          variableDcid: 'Count_Person',
+          entityDcid: 'geoId/48',
+          facets: [
+            {
+              facetId: 'f1',
+              source: 'Census',
+              sourceUrl: '',
+              unit: '',
+              earliestDate: '2020',
+              latestDate: '2020',
+              observationCount: 1,
+              observations: sampleObservations,
+            },
+          ],
+        },
+        {
+          variableDcid: 'Count_Person',
+          entityDcid: 'geoId/02',
+          facets: [
+            {
+              facetId: 'f2',
+              source: 'Census',
+              sourceUrl: '',
+              unit: '',
+              earliestDate: '2020',
+              latestDate: '2020',
+              observationCount: 1,
+              observations: sampleObservations,
+            },
+          ],
+        },
+        {
+          variableDcid: 'Count_Person',
+          entityDcid: 'geoId/06',
+          facets: [
+            {
+              facetId: 'f3',
+              source: 'Census',
+              sourceUrl: '',
+              unit: '',
+              earliestDate: '2020',
+              latestDate: '2020',
+              observationCount: 1,
+              observations: sampleObservations,
+            },
+          ],
+        },
+      ],
+    };
+
+    const content = deriveChartContent(result);
+    expect(content).not.toBeNull();
+    expect(content?.variant).toBe('chart');
+    if (content && content.variant === 'chart') {
+      const labels = content.series?.map((s) => s.label);
+      expect(labels).toEqual(['Alaska', 'California', 'Texas']);
+    }
+  });
+
+  // Test: deriveChartContentForVariable multi-entity alphabetization
+  // Situation: QueryResult has multiple entities in reverse order for a specific variable.
+  // Expectation: Resulting chart series are sorted alphabetically by entity name.
+  it('alphabetizes series by entity name in deriveChartContentForVariable', () => {
+    const result: QueryResult = {
+      id: 'res-2',
+      title: 'Income',
+      variables: [{ dcid: 'Median_Income', name: 'Median Income' }],
+      entities: [
+        { dcid: 'geoId/48', name: 'Texas' },
+        { dcid: 'geoId/06', name: 'California' },
+      ],
+      timeSeries: [
+        {
+          variableDcid: 'Median_Income',
+          entityDcid: 'geoId/48',
+          facets: [
+            {
+              facetId: 'f1',
+              source: 'Census',
+              sourceUrl: '',
+              unit: '$',
+              earliestDate: '2020',
+              latestDate: '2020',
+              observationCount: 1,
+              observations: sampleObservations,
+            },
+          ],
+        },
+        {
+          variableDcid: 'Median_Income',
+          entityDcid: 'geoId/06',
+          facets: [
+            {
+              facetId: 'f2',
+              source: 'Census',
+              sourceUrl: '',
+              unit: '$',
+              earliestDate: '2020',
+              latestDate: '2020',
+              observationCount: 1,
+              observations: sampleObservations,
+            },
+          ],
+        },
+      ],
+    };
+
+    const content = deriveChartContentForVariable(result, 'Median_Income');
+    expect(content).not.toBeNull();
+    if (content && content.variant === 'chart') {
+      const labels = content.series?.map((s) => s.label);
+      expect(labels).toEqual(['California', 'Texas']);
+    }
+  });
+
+  // Test: deriveComparisonChartContent cross-place alphabetization
+  // Situation: Comparison across multiple places (Texas, Alaska, California) for a single variable.
+  // Expectation: Series are sorted alphabetically by place name label.
+  it('alphabetizes series by place name in cross-place comparison charts', () => {
+    const comparison: ComparisonResult = {
+      id: 'comp-1',
+      title: 'State Comparison',
+      charts: [
+        {
+          variableDcid: 'Count_Person',
+          title: 'Population Comparison',
+          description: 'Comparison across states',
+        },
+      ],
+    };
+
+    const allResults: Record<string, QueryResult> = {
+      tx: {
+        id: 'tx',
+        title: 'Texas',
+        placeDcid: 'geoId/48',
+        placeName: 'Texas',
+        variables: [{ dcid: 'Count_Person', name: 'Population' }],
+        entities: [{ dcid: 'geoId/48', name: 'Texas' }],
+        timeSeries: [
+          {
+            variableDcid: 'Count_Person',
+            entityDcid: 'geoId/48',
+            facets: [
+              {
+                facetId: 'f1',
+                source: 'Census',
+                sourceUrl: '',
+                unit: '',
+                earliestDate: '2020',
+                latestDate: '2020',
+                observationCount: 1,
+                observations: sampleObservations,
+              },
+            ],
+          },
+        ],
+      },
+      ak: {
+        id: 'ak',
+        title: 'Alaska',
+        placeDcid: 'geoId/02',
+        placeName: 'Alaska',
+        variables: [{ dcid: 'Count_Person', name: 'Population' }],
+        entities: [{ dcid: 'geoId/02', name: 'Alaska' }],
+        timeSeries: [
+          {
+            variableDcid: 'Count_Person',
+            entityDcid: 'geoId/02',
+            facets: [
+              {
+                facetId: 'f2',
+                source: 'Census',
+                sourceUrl: '',
+                unit: '',
+                earliestDate: '2020',
+                latestDate: '2020',
+                observationCount: 1,
+                observations: sampleObservations,
+              },
+            ],
+          },
+        ],
+      },
+      ca: {
+        id: 'ca',
+        title: 'California',
+        placeDcid: 'geoId/06',
+        placeName: 'California',
+        variables: [{ dcid: 'Count_Person', name: 'Population' }],
+        entities: [{ dcid: 'geoId/06', name: 'California' }],
+        timeSeries: [
+          {
+            variableDcid: 'Count_Person',
+            entityDcid: 'geoId/06',
+            facets: [
+              {
+                facetId: 'f3',
+                source: 'Census',
+                sourceUrl: '',
+                unit: '',
+                earliestDate: '2020',
+                latestDate: '2020',
+                observationCount: 1,
+                observations: sampleObservations,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const content = deriveComparisonChartContent(
+      comparison,
+      'Count_Person',
+      allResults,
+    );
+    expect(content).not.toBeNull();
+    if (content && content.variant === 'chart') {
+      const labels = content.series?.map((s) => s.label);
+      expect(labels).toEqual(['Alaska', 'California', 'Texas']);
+    }
+  });
+
+  // Test: deriveComparisonChartContent same-place variable alphabetization
+  // Situation: Same-place comparison overlaying multiple variables.
+  // Expectation: Series are sorted alphabetically by variable name.
+  it('alphabetizes series by variable name in same-place comparison charts', () => {
+    const comparison: ComparisonResult = {
+      id: 'comp-2',
+      title: 'City Metrics',
+      charts: [
+        {
+          variableDcid: 'Var_A',
+          title: 'Metrics Comparison',
+          description: 'Comparing variables in one city',
+        },
+      ],
+    };
+
+    const allResults: Record<string, QueryResult> = {
+      sf: {
+        id: 'sf',
+        title: 'San Francisco',
+        placeDcid: 'geoId/0667000',
+        placeName: 'San Francisco',
+        variables: [
+          { dcid: 'Var_Z', name: 'Zebra Count' },
+          { dcid: 'Var_A', name: 'Apple Yield' },
+          { dcid: 'Var_M', name: 'Mango Output' },
+        ],
+        entities: [{ dcid: 'geoId/0667000', name: 'San Francisco' }],
+        timeSeries: [
+          {
+            variableDcid: 'Var_Z',
+            entityDcid: 'geoId/0667000',
+            facets: [
+              {
+                facetId: 'fZ',
+                source: 'USDA',
+                sourceUrl: '',
+                unit: '',
+                earliestDate: '2020',
+                latestDate: '2020',
+                observationCount: 1,
+                observations: sampleObservations,
+              },
+            ],
+          },
+          {
+            variableDcid: 'Var_A',
+            entityDcid: 'geoId/0667000',
+            facets: [
+              {
+                facetId: 'fA',
+                source: 'USDA',
+                sourceUrl: '',
+                unit: '',
+                earliestDate: '2020',
+                latestDate: '2020',
+                observationCount: 1,
+                observations: sampleObservations,
+              },
+            ],
+          },
+          {
+            variableDcid: 'Var_M',
+            entityDcid: 'geoId/0667000',
+            facets: [
+              {
+                facetId: 'fM',
+                source: 'USDA',
+                sourceUrl: '',
+                unit: '',
+                earliestDate: '2020',
+                latestDate: '2020',
+                observationCount: 1,
+                observations: sampleObservations,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const content = deriveComparisonChartContent(
+      comparison,
+      'Var_A',
+      allResults,
+    );
+    expect(content).not.toBeNull();
+    if (content && content.variant === 'chart') {
+      const labels = content.series?.map((s) => s.label);
+      expect(labels).toEqual(['Apple Yield', 'Mango Output', 'Zebra Count']);
+    }
+  });
+});

--- a/dataweaver/apps/web/src/components/scopes/atlas/sync_store.test.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/sync_store.test.ts
@@ -1,19 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ComparisonResult, QueryResult } from '~/server/types';
-import {
-  deriveChartContent,
-  deriveChartContentForVariable,
-  deriveComparisonChartContent,
-} from './sync_store';
+import { deriveContentForCard } from './sync_store';
 
 describe('sync_store multi-series alphabetization', () => {
   const sampleObservations = [{ date: '2020', value: 100 }];
 
-  // Test: deriveChartContent multi-entity alphabetization
+  // Test: deriveContentForCard multi-entity alphabetization
   // Situation: QueryResult contains multiple entities in non-alphabetical order (Texas, Alaska, California).
   // Expectation: Resulting chart series are sorted alphabetically by label (Alaska, California, Texas).
-  it('alphabetizes series by entity name in deriveChartContent', () => {
+  it('alphabetizes series by entity name in multi-entity charts', () => {
     const result: QueryResult = {
       id: 'res-1',
       title: 'Population',
@@ -75,7 +71,7 @@ describe('sync_store multi-series alphabetization', () => {
       ],
     };
 
-    const content = deriveChartContent(result);
+    const content = deriveContentForCard('chart', result);
     expect(content).not.toBeNull();
     expect(content?.variant).toBe('chart');
     if (content && content.variant === 'chart') {
@@ -84,10 +80,10 @@ describe('sync_store multi-series alphabetization', () => {
     }
   });
 
-  // Test: deriveChartContentForVariable multi-entity alphabetization
+  // Test: deriveContentForCard for variable multi-entity alphabetization
   // Situation: QueryResult has multiple entities in reverse order for a specific variable.
   // Expectation: Resulting chart series are sorted alphabetically by entity name.
-  it('alphabetizes series by entity name in deriveChartContentForVariable', () => {
+  it('alphabetizes series by entity name in variable-specific charts', () => {
     const result: QueryResult = {
       id: 'res-2',
       title: 'Income',
@@ -132,7 +128,12 @@ describe('sync_store multi-series alphabetization', () => {
       ],
     };
 
-    const content = deriveChartContentForVariable(result, 'Median_Income');
+    const content = deriveContentForCard(
+      'chart',
+      result,
+      undefined,
+      'Median_Income',
+    );
     expect(content).not.toBeNull();
     if (content && content.variant === 'chart') {
       const labels = content.series?.map((s) => s.label);
@@ -140,7 +141,7 @@ describe('sync_store multi-series alphabetization', () => {
     }
   });
 
-  // Test: deriveComparisonChartContent cross-place alphabetization
+  // Test: deriveContentForCard cross-place alphabetization
   // Situation: Comparison across multiple places (Texas, Alaska, California) for a single variable.
   // Expectation: Series are sorted alphabetically by place name label.
   it('alphabetizes series by place name in cross-place comparison charts', () => {
@@ -237,9 +238,12 @@ describe('sync_store multi-series alphabetization', () => {
       },
     };
 
-    const content = deriveComparisonChartContent(
-      comparison,
+    const content = deriveContentForCard(
+      'chart',
+      undefined,
+      undefined,
       'Count_Person',
+      comparison,
       allResults,
     );
     expect(content).not.toBeNull();
@@ -249,9 +253,9 @@ describe('sync_store multi-series alphabetization', () => {
     }
   });
 
-  // Test: deriveComparisonChartContent same-place variable alphabetization
+  // Test: deriveContentForCard same-place variable alphabetization
   // Situation: Same-place comparison overlaying multiple variables.
-  // Expectation: Series are sorted alphabetically by variable name.
+  // Expectation: Series are sorted alphabetically by variable name using deterministic English locale.
   it('alphabetizes series by variable name in same-place comparison charts', () => {
     const comparison: ComparisonResult = {
       id: 'comp-2',
@@ -330,9 +334,12 @@ describe('sync_store multi-series alphabetization', () => {
       },
     };
 
-    const content = deriveComparisonChartContent(
-      comparison,
+    const content = deriveContentForCard(
+      'chart',
+      undefined,
+      undefined,
       'Var_A',
+      comparison,
       allResults,
     );
     expect(content).not.toBeNull();

--- a/dataweaver/apps/web/src/components/scopes/atlas/sync_store.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/sync_store.ts
@@ -147,6 +147,8 @@ export const deriveComparisonChartContent = (
 
   if (series.length === 0) return null;
 
+  series.sort((a, b) => a.label.localeCompare(b.label));
+
   return {
     variant: 'chart',
     title: chartMeta.title,
@@ -192,6 +194,8 @@ export const deriveChartContent = (
     }
 
     if (series.length === 0) return null;
+
+    series.sort((a, b) => a.label.localeCompare(b.label));
 
     const varName = result.variables[0]?.name;
     const title = formatChartCardTitle(varName, placeName, result.isChildQuery);
@@ -265,6 +269,8 @@ export const deriveChartContentForVariable = (
     }
 
     if (series.length === 0) return null;
+
+    series.sort((a, b) => a.label.localeCompare(b.label));
 
     const variable = result.variables.find((v) => v.dcid === variableDcid);
     const title = formatChartCardTitle(

--- a/dataweaver/apps/web/src/components/scopes/atlas/sync_store.ts
+++ b/dataweaver/apps/web/src/components/scopes/atlas/sync_store.ts
@@ -147,8 +147,6 @@ export const deriveComparisonChartContent = (
 
   if (series.length === 0) return null;
 
-  series.sort((a, b) => a.label.localeCompare(b.label));
-
   return {
     variant: 'chart',
     title: chartMeta.title,
@@ -194,8 +192,6 @@ export const deriveChartContent = (
     }
 
     if (series.length === 0) return null;
-
-    series.sort((a, b) => a.label.localeCompare(b.label));
 
     const varName = result.variables[0]?.name;
     const title = formatChartCardTitle(varName, placeName, result.isChildQuery);
@@ -270,8 +266,6 @@ export const deriveChartContentForVariable = (
 
     if (series.length === 0) return null;
 
-    series.sort((a, b) => a.label.localeCompare(b.label));
-
     const variable = result.variables.find((v) => v.dcid === variableDcid);
     const title = formatChartCardTitle(
       variable?.name,
@@ -336,7 +330,7 @@ export const deriveContentForCard = (
     return deriveComparisonContent(comparison);
   }
   if (comparison && type === 'chart' && variableDcid && allResults) {
-    return withChartStyle(
+    return finalizeChartContent(
       deriveComparisonChartContent(comparison, variableDcid, allResults),
       chartStyle,
     );
@@ -351,17 +345,30 @@ export const deriveContentForCard = (
       const content = variableDcid
         ? deriveChartContentForVariable(result, variableDcid)
         : deriveChartContent(result);
-      return withChartStyle(content, chartStyle);
+      return finalizeChartContent(content, chartStyle);
     }
   }
 };
 
-/** Apply a persisted chart style override to derived chart content. */
-const withChartStyle = (
+/** Sort series alphabetically by label using deterministic English locale to prevent SSR hydration mismatches. */
+const sortSeries = (series: ChartSeries[]): ChartSeries[] =>
+  series.sort((a, b) =>
+    (a.label ?? '').localeCompare(b.label ?? '', 'en', {
+      sensitivity: 'base',
+      numeric: true,
+    }),
+  );
+
+/** Finalize chart content: sort multi-series data alphabetically and apply chart style override. */
+const finalizeChartContent = (
   content: AtlasContent | null,
   chartStyle?: ChartStyle,
 ): AtlasContent | null => {
-  if (content && chartStyle && content.variant === 'chart') {
+  if (!content || content.variant !== 'chart') return content;
+  if (content.series && content.series.length > 1) {
+    sortSeries(content.series);
+  }
+  if (chartStyle) {
     return { ...content, chartStyle };
   }
   return content;


### PR DESCRIPTION
## Description

This PR improves chart tooltips and legends by:
* including the series discriminator (entity names) to tooltips
* protect against NaN for missing values by replacing them with em-dashes
* Sorting series alphabetically across the card lifecycle.

## Note

Most of the diff in this PR is in added tests.

## Testing
* Unit tests verified with `pnpm test` (all 10 suites, 65 tests passed).
* Linting
* Build and build run-time verified.

## Screenshots

### Before

<img width="505" height="517" alt="before" src="https://github.com/user-attachments/assets/bbaffc4e-080e-40aa-a6aa-7fd989f7b5f0" />

### After

<img width="884" height="598" alt="image" src="https://github.com/user-attachments/assets/0e446af0-31d5-49d4-8ff9-e815e3af85bb" />
